### PR TITLE
Use Klipper's nodeid to canbus_id scheme

### DIFF
--- a/scripts/flash_can.py
+++ b/scripts/flash_can.py
@@ -56,7 +56,7 @@ CANBUS_CMD_QUERY_UNASSIGNED = 0x00
 CANBUS_CMD_SET_NODEID = 0x11
 CANBUS_CMD_CLEAR_NODE_ID = 0x12
 CANBUS_RESP_NEED_NODEID = 0x20
-CANBUS_NODE_OFFSET = 0x200
+CANBUS_NODEID_OFFSET = 128
 
 class FlashCanError(Exception):
     pass
@@ -356,11 +356,11 @@ class CanSocket:
         # Convert ID to a list
         plist = [(uuid >> ((5 - i) * 8)) & 0xFF for i in range(6)]
         plist.insert(0, CANBUS_CMD_SET_NODEID)
-        node_id = len(self.nodes)
+        node_id = len(self.nodes) + CANBUS_NODEID_OFFSET
         plist.append(node_id)
         payload = bytes(plist)
         self.admin_node.write(payload)
-        decoded_id = node_id * 2 + CANBUS_NODE_OFFSET
+        decoded_id = node_id * 2 + 0x100
         node = CanNode(decoded_id, self)
         self.nodes[decoded_id + 1] = node
         return node

--- a/src/generic/canbus.c
+++ b/src/generic/canbus.c
@@ -106,7 +106,7 @@ can_check_uuid(uint32_t id, uint32_t len, uint8_t *data)
 static uint32_t
 can_decode_nodeid(int nodeid)
 {
-    return (nodeid << 1) + 0x200;
+    return (nodeid << 1) + 0x100;
 }
 
 static void


### PR DESCRIPTION
Use Klipper's nodeid to canbus_id scheme (`canbus_id = nodeid * 2 + 0x100`).  Instead, use a nodeid offset of 128 to avoid collisions with Klipper.

Using different nodeids instead of a different nodeid mapping may be easier for developers and users to understand.  Currently klippy uses nodeids starting at 0, console.py in the Klipper repo uses nodeids starting at 64, and this PR would set canboot to use nodeids starting at 128.

Note that this change would break flash_can.py for any existing canboot installations.

-Kevin