### PR TITLE
Makefile: Build with -Os instead of -O2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ dirs-y = src
 cc-option=$(shell if test -z "`$(1) $(2) -S -o /dev/null -xc /dev/null 2>&1`" \
     ; then echo "$(2)"; else echo "$(3)"; fi ;)
 
-CFLAGS := -I$(OUT) -Isrc -I$(OUT)board-generic/ -std=gnu11 -O2 -MD -g \
+CFLAGS := -I$(OUT) -Isrc -I$(OUT)board-generic/ -std=gnu11 -Os -MD -g \
     -Wall -Wold-style-definition $(call cc-option,$(CC),-Wtype-limits,) \
     -ffunction-sections -fdata-sections
 CFLAGS += -flto -fwhole-program -fno-use-linker-plugin


### PR DESCRIPTION
Build size is likely more important than CPU performance for a bootloader.  So, instruct gcc to optimize for size by default.

On my fedora build of the stm32f103 code (with led support) going from -O2 to -Os changed the build from 4080 bytes to 3368 bytes (a ~20% reduction in size).

-Kevin