### PR TITLE
Do hardware reset before application start

### DIFF
--- a/src/canboot_main.c
+++ b/src/canboot_main.c
@@ -266,22 +266,20 @@ enter_bootloader(void)
 void
 canboot_main(void)
 {
-    uint32_t req_addr = *(uint32_t *)CONFIG_FLASH_START;
-    volatile uint64_t* boot_request_sig = (volatile uint64_t *)req_addr;
-
     // Enter the bootloader in the following conditions:
     // - The request signature is set in memory (request from app)
     // - No application code is present
-    if ((*boot_request_sig == REQUEST_SIG ) || !check_application_code()) {
-        *boot_request_sig = 0;
+    uint64_t bootup_code = get_bootup_code();
+    if (bootup_code == REQUEST_SIG || !check_application_code()) {
+        set_bootup_code(0);
         enter_bootloader();
     }
 
     // set request signature and delay for two seconds.  This enters the bootloader if
     // the reset button is double clicked
-    *boot_request_sig = REQUEST_SIG;
+    set_bootup_code(REQUEST_SIG);
     udelay(2000000);
-    *boot_request_sig = 0;
+    set_bootup_code(0);
     // No reset, read the key back out to clear it
 
     // jump to app

--- a/src/generic/armcm_boot.c
+++ b/src/generic/armcm_boot.c
@@ -18,6 +18,20 @@ extern uint32_t _stack_end;
  * Basic interrupt handlers
  ****************************************************************/
 
+uint64_t
+get_bootup_code(void)
+{
+    uint64_t *req_code = (void*)&_stack_end;
+    return *req_code;
+}
+
+void
+set_bootup_code(uint64_t code)
+{
+    uint64_t *req_code = (void*)&_stack_end;
+    *req_code = code;
+}
+
 void __noreturn __visible
 reset_handler_stage_two(void)
 {

--- a/src/generic/misc.h
+++ b/src/generic/misc.h
@@ -5,6 +5,8 @@
 #include <stdint.h> // uint8_t
 #include "autoconf.h" // CONFIG_MACH_STM32F0
 
+uint64_t get_bootup_code(void);
+void set_bootup_code(uint64_t code);
 void jump_to_application(void);
 
 // Timer Functions

--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -115,19 +115,3 @@ armcm_main(void)
     timer_init();
     canboot_main();
 }
-
-typedef void (*func_ptr)(void);
-
-void
-jump_to_application(void)
-{
-    func_ptr application = (func_ptr) *(volatile uint32_t*)
-        (CONFIG_APPLICATION_START + 0x04);
-
-    // Set the main stack pointer
-    asm volatile ("MSR msp, %0" : : "r" (*(volatile uint32_t*)
-        CONFIG_APPLICATION_START) : );
-
-    // Jump to application
-    application();
-}

--- a/src/stm32/stm32f1.c
+++ b/src/stm32/stm32f1.c
@@ -237,26 +237,3 @@ armcm_main(void)
 
     canboot_main();
 }
-
-typedef void (*func_ptr)(void);
-
-void
-jump_to_application(void)
-{
-    func_ptr application = (func_ptr) *(volatile uint32_t*)
-        (CONFIG_APPLICATION_START + 0x04);
-
-    // Reset clocks
-    RCC->AHBENR = 0x14;
-    RCC->APB1ENR = 0;
-    RCC->APB2ENR = 0;
-
-    // Reset the Vector table to the application address
-    SCB->VTOR = CONFIG_APPLICATION_START;
-    // Set the main stack pointer
-    asm volatile ("MSR msp, %0" : : "r" (*(volatile uint32_t*)
-        CONFIG_APPLICATION_START) : );
-
-    // Jump to application
-    application();
-}


### PR DESCRIPTION
This PR simplifies the `jump_to_application()` code by utilizing the existing "request signature" system.  The code can set a "request application startup" flag, then do a full cpu reset, and then launch the application in the early bootup code (before doing any cpu init).  This should also make cpu initialization more reliable.

I chose the `REQUEST_START_APP` code randomly (`head -c 8 /dev/random | hexdump -C`).

-Kevin