### PR TITLE
Autodetect stm32f103 flash page size

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -167,21 +167,10 @@ config STM32F0_TRIM
         Default is 16 (use factory default). Each increment increases
         the clock rate by ~240KHz.
 
-choice
-depends on MACH_STM32F103
-prompt "Flash Page Size"
-config STM32F1_PAGE_SIZE_400
-    bool "Low/Medium Density (1024 KiB Page Size)"
-config STM32F1_PAGE_SIZE_800
-    bool "High Density (2048 KiB Page Size)"
-endchoice
-
-config FLASH_PAGE_SIZE
+config MAX_FLASH_PAGE_SIZE
     hex
     default 0x400 if MACH_STM32F042
-    default 0x800 if MACH_STM32F072
-    default 0x400 if MACH_STM32F103 && STM32F1_PAGE_SIZE_400
-    default 0x800 if MACH_STM32F103 && STM32F1_PAGE_SIZE_800
+    default 0x800 if MACH_STM32F072 || MACH_STM32F103
     default 0x400
 
 config BLOCK_SIZE

--- a/src/stm32/flash.h
+++ b/src/stm32/flash.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+uint32_t flash_get_page_size(void);
 void flash_complete(void);
 void flash_write_page(uint16_t page_index, uint16_t *data);
 void flash_read_block(uint16_t block_index, uint32_t *buffer);


### PR DESCRIPTION
I expect it will be difficult for many users to determine if they need a 1K or 2K page size on the stm32f103.  As near as I can tell, this can be auto-detected by inspecting the flash size on the stm32f103 - only devices with 256K or more of flash have a 2K page size.

This PR updates the code to attempt to auto-detect the flash page size at runtime.

-Kevin