### PR TITLE
Call timer_setup() from sched_main()

### DIFF
--- a/src/bootentry.c
+++ b/src/bootentry.c
@@ -6,11 +6,12 @@
 
 #include <string.h>         // strlen
 #include "autoconf.h"       // CONFIG_*
-#include "board/misc.h"     // udelay
 #include "board/flash.h"    // flash_read_block
 #include "board/gpio.h"     // gpio_in_setup
+#include "board/misc.h"     // set_bootup_code
 #include "bootentry.h"      // bootentry_check
 #include "ctr.h"            // DECL_CTR
+#include "sched.h"          // udelay
 
 #define REQUEST_SIG    0x5984E3FA6CA1589B // Random request sig
 

--- a/src/generic/armcm_timer.c
+++ b/src/generic/armcm_timer.c
@@ -35,16 +35,10 @@ timer_read_time(void)
     return DWT->CYCCNT;
 }
 
-// Implement simple early-boot delay mechanism
+// Initialize the timer
 void
-udelay(uint32_t usecs)
+timer_setup(void)
 {
-    if (!(CoreDebug->DEMCR & CoreDebug_DEMCR_TRCENA_Msk)) {
-        CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
-        DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
-    }
-
-    uint32_t end = timer_read_time() + timer_from_us(usecs);
-    while (timer_is_before(timer_read_time(), end))
-        ;
+    CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+    DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
 }

--- a/src/generic/misc.h
+++ b/src/generic/misc.h
@@ -12,8 +12,7 @@ uint64_t get_bootup_code(void);
 void set_bootup_code(uint64_t code);
 void jump_to_application(void);
 
-void timer_init(void);
-void udelay(uint32_t usecs);
+void timer_setup(void);
 
 uint32_t timer_from_us(uint32_t us);
 uint8_t timer_is_before(uint32_t time1, uint32_t time2);

--- a/src/led.c
+++ b/src/led.c
@@ -24,9 +24,6 @@ void
 led_init(void)
 {
     led = gpio_out_setup(led_gpio, led_gpio_high);
-    // The short delay is simply to ensure that the Debug Timer is
-    // enabled
-    udelay(10);
     last_blink_time = timer_read_time();
 }
 DECL_INIT(led_init);

--- a/src/sched.c
+++ b/src/sched.c
@@ -9,6 +9,15 @@
 #include "bootentry.h" // bootentry_check
 #include "sched.h" // sched_check_periodic
 
+// Implement simple delay mechanism
+void
+udelay(uint32_t usecs)
+{
+    uint32_t end = timer_read_time() + timer_from_us(usecs);
+    while (timer_is_before(timer_read_time(), end))
+        ;
+}
+
 // Wrapper for Klipper compatibility
 void
 sched_wake_tasks(void)
@@ -36,6 +45,7 @@ sched_check_wake(struct task_wake *w)
 void
 sched_main(void)
 {
+    timer_setup();
     if (!bootentry_check())
         jump_to_application();
 

--- a/src/sched.h
+++ b/src/sched.h
@@ -17,6 +17,7 @@ struct task_wake {
 };
 
 // sched.c
+void udelay(uint32_t usecs);
 void sched_wake_tasks(void);
 void sched_wake_task(struct task_wake *w);
 uint8_t sched_check_wake(struct task_wake *w);

--- a/src/stm32/stm32f0.c
+++ b/src/stm32/stm32f0.c
@@ -7,7 +7,6 @@
 #include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
 #include "board/armcm_boot.h" // armcm_main
 #include "board/irq.h" // irq_disable
-#include "board/misc.h" // timer_init
 #include "command.h" // DECL_CONSTANT_STR
 #include "internal.h" // enable_pclock
 #include "sched.h" // sched_main
@@ -159,6 +158,5 @@ armcm_main(void)
         SYSCFG->CFGR1 |= SYSCFG_CFGR1_PA11_PA12_RMP;
 #endif
 
-    timer_init();
     sched_main();
 }

--- a/src/stm32/stm32f0_timer.c
+++ b/src/stm32/stm32f0_timer.c
@@ -73,8 +73,9 @@ TIMx_IRQHandler(void)
     irq_enable();
 }
 
+// Initialize the timer
 void
-timer_init(void)
+timer_setup(void)
 {
     irqstatus_t flag = irq_save();
     enable_pclock((uint32_t)TIMx);
@@ -103,13 +104,4 @@ uint8_t
 timer_is_before(uint32_t time1, uint32_t time2)
 {
     return (int32_t)(time1 - time2) < 0;
-}
-
-// Implement simple early-boot delay mechanism
-void
-udelay(uint32_t usecs)
-{
-    uint32_t end = timer_read_time() + timer_from_us(usecs);
-    while (timer_is_before(timer_read_time(), end))
-        ;
 }


### PR DESCRIPTION
Explicitly enable the timer (via a new `timer_setup()` call from sched_main.  This is a minor change that saves a few bytes in the final binary.

-Kevin