### PR TITLE
Add support for initial pins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ OBJCOPY=$(CROSS_PREFIX)objcopy
 OBJDUMP=$(CROSS_PREFIX)objdump
 STRIP=$(CROSS_PREFIX)strip
 CPP=cpp
-PYTHON=python2
+PYTHON=python3
 
 # Source files
 src-y =

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -44,6 +44,17 @@ config USB_SERIAL_NUMBER
     string "USB serial number" if !USB_SERIAL_NUMBER_CHIPID
 endmenu
 
+config INITIAL_PINS
+    string "GPIO pins to set on bootloader entry"
+    depends on LOW_LEVEL_OPTIONS
+    help
+        One may specify a comma separated list of gpio pins to set
+        during bootloader entry (these gpio pins are not set if the
+        main application is started nor are they set while checking
+        for a bootloader request). By default the pins will be set to
+        output high - preface a pin with a '!' character to set that
+        pin to output low.
+
 config ENABLE_DOUBLE_RESET
     bool "Support bootloader entry on rapid double click of reset button"
     default y

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
 # Main code build rules
 
-src-y += sched.c bootentry.c command.c flashcmd.c
+src-y += sched.c bootentry.c command.c flashcmd.c initial_pins.c
 src-$(CONFIG_ENABLE_LED) += led.c

--- a/src/initial_pins.c
+++ b/src/initial_pins.c
@@ -1,0 +1,25 @@
+// Support setting gpio pins at mcu start
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_INITIAL_PINS
+#include "board/gpio.h" // gpio_out_setup
+#include "board/pgm.h" // READP
+#include "ctr.h" // DECL_CTR
+#include "initial_pins.h" // initial_pins
+#include "sched.h" // DECL_INIT
+
+DECL_CTR("DECL_INITIAL_PINS " __stringify(CONFIG_INITIAL_PINS));
+
+void
+initial_pins_setup(void)
+{
+    int i;
+    for (i=0; i<initial_pins_size; i++) {
+        const struct initial_pin_s *ip = &initial_pins[i];
+        gpio_out_setup(READP(ip->pin), READP(ip->flags) & IP_OUT_HIGH);
+    }
+}
+DECL_INIT(initial_pins_setup);

--- a/src/initial_pins.h
+++ b/src/initial_pins.h
@@ -1,0 +1,15 @@
+#ifndef __INITIAl_PINS_H
+#define __INITIAl_PINS_H
+
+struct initial_pin_s {
+    int pin;
+    uint8_t flags;
+};
+
+enum { IP_OUT_HIGH = 1 };
+
+// out/compile_time_request.c (auto generated file)
+extern const struct initial_pin_s initial_pins[];
+extern const int initial_pins_size;
+
+#endif // initial_pins.h


### PR DESCRIPTION
Some boards require gpio setup in order to use USB.  This ports the "initial pins" capability from Klipper to support that.

-Kevin