### PR TITLE
Support 4KiB application start

### DIFF
--- a/scripts/buildbinary.py
+++ b/scripts/buildbinary.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# Tool to check final CanBoot binary size
+#
+# Copyright (C) 2022  Kevin O'Connor <kevin@koconnor.net>
+#
+# This file may be distributed under the terms of the GNU GPLv3 license.
+import sys, argparse
+
+ERR_MSG = """
+The CanBoot binary is too large for the configured APPLICATION_START.
+
+Rerun "make menuconfig" and either increase the APPLICATION_START or
+disable features to reduce the final binary size.
+"""
+
+def main():
+    parser = argparse.ArgumentParser(description="Build CanBoot binary")
+    parser.add_argument("-b", "--base", help="Address of flash start")
+    parser.add_argument("-s", "--start", help="Address of application start")
+    parser.add_argument("input_file", help="Raw binary filename")
+    parser.add_argument("output_file", help="Final binary filename")
+    args = parser.parse_args()
+
+    start = int(args.start, 0)
+    base = int(args.base, 0)
+    max_size = start - base
+
+    f = open(args.input_file, 'rb')
+    data = f.read()
+    f.close()
+
+    if len(data) > max_size:
+        msg = "\nMaximum size %d. Current size %d.\n\n" % (max_size, len(data))
+        sys.stderr.write(ERR_MSG + msg)
+        sys.exit(-1)
+
+    f = open(args.output_file, 'wb')
+    f.write(data)
+    f.close()
+
+if __name__ == '__main__':
+    main()

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -341,11 +341,20 @@ config CANBUS_FREQUENCY
 # Flash settings
 ######################################################################
 
+choice
+    prompt "Application start offset"
+    depends on MACH_STM32F0 || MACH_STM32F1
+    config STM32_APP_START_1000
+        bool "4KiB offset"
+    config STM32_APP_START_2000
+        bool "8KiB offset"
+endchoice
+
 config APPLICATION_START
     hex
-    default 0x8002000 if MACH_STM32F103
-    default 0x8008000 if MACH_STM32F4
-    default 0x8002000
+    default 0x8001000 if STM32_APP_START_1000
+    default 0x8002000 if STM32_APP_START_2000
+    default 0x8008000
 
 config MAX_FLASH_PAGE_SIZE
     hex

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -59,4 +59,5 @@ target-y += $(OUT)canboot.bin
 
 $(OUT)canboot.bin: $(OUT)canboot.elf
 	@echo "  Creating hex file $@"
-	$(Q)$(OBJCOPY) -O binary $< $@
+	$(Q)$(OBJCOPY) -O binary $< $(OUT)canboot.work
+	$(Q)$(PYTHON) ./scripts/buildbinary.py -b $(CONFIG_FLASH_START) -s $(CONFIG_APPLICATION_START) $(OUT)canboot.work $@


### PR DESCRIPTION
This allows stm32 f0 and f1 devices to support either 4K or 8K bootloader size.  It also adds a build check to verify the final binary fits within the requested size.

I have an stm32f042 device with only 32KiB of flash - using a 4K bootloader size really helps on that device.

-Kevin