### PR TITLE
Add compile time check to initial_pins to reduce binary size

### DIFF
--- a/src/initial_pins.c
+++ b/src/initial_pins.c
@@ -16,6 +16,8 @@ DECL_CTR("DECL_INITIAL_PINS " __stringify(CONFIG_INITIAL_PINS));
 void
 initial_pins_setup(void)
 {
+    if (sizeof(CONFIG_INITIAL_PINS) <= 1)
+        return;
     int i;
     for (i=0; i<initial_pins_size; i++) {
         const struct initial_pin_s *ip = &initial_pins[i];


### PR DESCRIPTION
It seems the initial_pins code is adding a few hundred bytes to the final binary size even when not in use.  I didn't realize that.  It's easy to add a gcc check to optimize it out.  If all looks okay, I'll add the same check to Klipper.

-Kevin