### PR TITLE
Default to 8KiB app start on f0/f1 ; Allow 16KiB on f4

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -343,15 +343,20 @@ config CANBUS_FREQUENCY
 
 choice
     prompt "Application start offset"
-    depends on MACH_STM32F0 || MACH_STM32F1
+    config STM32_APP_START_8000
+        bool "32KiB offset" if MACH_STM32F4
+    config STM32_APP_START_4000
+        bool "16KiB offset" if MACH_STM32F4
     config STM32_APP_START_2000
-        bool "8KiB offset"
+        bool "8KiB offset" if MACH_STM32F0 || MACH_STM32F1
     config STM32_APP_START_1000
-        bool "4KiB offset"
+        bool "4KiB offset" if MACH_STM32F0 || MACH_STM32F1
 endchoice
 
 config APPLICATION_START
     hex
+    default 0x8008000 if STM32_APP_START_8000
+    default 0x8004000 if STM32_APP_START_4000
     default 0x8002000 if STM32_APP_START_2000
     default 0x8001000 if STM32_APP_START_1000
     default 0x8008000

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -344,16 +344,16 @@ config CANBUS_FREQUENCY
 choice
     prompt "Application start offset"
     depends on MACH_STM32F0 || MACH_STM32F1
-    config STM32_APP_START_1000
-        bool "4KiB offset"
     config STM32_APP_START_2000
         bool "8KiB offset"
+    config STM32_APP_START_1000
+        bool "4KiB offset"
 endchoice
 
 config APPLICATION_START
     hex
-    default 0x8001000 if STM32_APP_START_1000
     default 0x8002000 if STM32_APP_START_2000
+    default 0x8001000 if STM32_APP_START_1000
     default 0x8008000
 
 config BLOCK_SIZE


### PR DESCRIPTION
I inadvertently changed the default of f0/f1 to 4KiB application start in commit d6c874b0.  This restores the default of 8KiB (which I suspect is less likely to confuse new users).

While I was at it, I also enabled a 16KiB app start on F4.  The default remains 32KiB.

-Kevin