### PR TITLE
Resync stm32f4 with upstream Klipper

### DIFF
--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -16,7 +16,6 @@ CFLAGS-$(CONFIG_MACH_STM32F0) += -mcpu=cortex-m0 -Ilib/stm32f0/include
 CFLAGS-$(CONFIG_MACH_STM32F1) += -mcpu=cortex-m3 -Ilib/stm32f1/include
 CFLAGS-$(CONFIG_MACH_STM32F2) += -mcpu=cortex-m3 -Ilib/stm32f2/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mcpu=cortex-m4 -Ilib/stm32f4/include
-CFLAGS-$(CONFIG_MACH_STM32F4) += -mfpu=fpv4-sp-d16 -mfloat-abi=hard
 CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
 CFLAGS_canboot.elf += --specs=nano.specs --specs=nosys.specs

--- a/src/stm32/stm32f4.c
+++ b/src/stm32/stm32f4.c
@@ -8,6 +8,7 @@
 #include "board/armcm_boot.h" // VectorTable
 #include "board/irq.h" // irq_disable
 #include "board/usb_cdc.h" // usb_request_bootloader
+#include "command.h" // DECL_CONSTANT_STR
 #include "internal.h" // enable_pclock
 #include "sched.h" // sched_main
 
@@ -54,6 +55,10 @@ gpio_clock_enable(GPIO_TypeDef *regs)
     RCC->AHB1ENR |= 1 << rcc_pos;
     RCC->AHB1ENR;
 }
+
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL
+DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PH0,PH1");
+#endif
 
 // Clock configuration
 static void
@@ -158,7 +163,7 @@ clock_setup(void)
     // Configure and enable PLL
     if (CONFIG_MACH_STM32F207)
         enable_clock_stm32f20x();
-    else if (CONFIG_MACH_STM32F4x5)
+    else if (CONFIG_MACH_STM32F401 || CONFIG_MACH_STM32F4x5)
         enable_clock_stm32f40x();
     else
         enable_clock_stm32f446();


### PR DESCRIPTION
There was a Klipper bugfix for STM32F401 clock init.

There was a Klipper build bugfix when building with gcc hardfloat flags.

-Kevin