### PR TITLE
Support for additional stm32 chips

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -65,7 +65,7 @@ choice
         select MACH_STM32F0
         select MACH_STM32F0x2
     config MACH_STM32G0B1
-        bool "STM32G0B1" if 0
+        bool "STM32G0B1"
         select MACH_STM32G0
     config MACH_STM32H743
         bool "STM32H743" if 0
@@ -348,9 +348,9 @@ choice
     config STM32_APP_START_4000
         bool "16KiB offset" if MACH_STM32F2 || MACH_STM32F4
     config STM32_APP_START_2000
-        bool "8KiB offset" if MACH_STM32F0 || MACH_STM32F1
+        bool "8KiB offset" if MACH_STM32F0 || MACH_STM32F1 || MACH_STM32G0
     config STM32_APP_START_1000
-        bool "4KiB offset" if MACH_STM32F0 || MACH_STM32F1
+        bool "4KiB offset" if MACH_STM32F0 || MACH_STM32F1 || MACH_STM32G0
 endchoice
 
 config APPLICATION_START

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -30,7 +30,7 @@ choice
         bool "STM32F103"
         select MACH_STM32F1
     config MACH_STM32F207
-        bool "STM32F207" if 0
+        bool "STM32F207"
         select MACH_STM32F2
     config MACH_STM32F401
         bool "STM32F401"
@@ -344,9 +344,9 @@ config CANBUS_FREQUENCY
 choice
     prompt "Application start offset"
     config STM32_APP_START_8000
-        bool "32KiB offset" if MACH_STM32F4
+        bool "32KiB offset" if MACH_STM32F2 || MACH_STM32F4
     config STM32_APP_START_4000
-        bool "16KiB offset" if MACH_STM32F4
+        bool "16KiB offset" if MACH_STM32F2 || MACH_STM32F4
     config STM32_APP_START_2000
         bool "8KiB offset" if MACH_STM32F0 || MACH_STM32F1
     config STM32_APP_START_1000

--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -51,14 +51,14 @@ choice
         bool "STM32F446"
         select MACH_STM32F4
     config MACH_STM32F031
-        bool "STM32F031" if 0
+        bool "STM32F031"
         select MACH_STM32F0
     config MACH_STM32F042
         bool "STM32F042"
         select MACH_STM32F0
         select MACH_STM32F0x2
     config MACH_STM32F070
-        bool "STM32F070" if 0
+        bool "STM32F070"
         select MACH_STM32F0
     config MACH_STM32F072
         bool "STM32F072"

--- a/src/stm32/Makefile
+++ b/src/stm32/Makefile
@@ -8,6 +8,7 @@ dirs-$(CONFIG_MACH_STM32F0) += lib/stm32f0
 dirs-$(CONFIG_MACH_STM32F1) += lib/stm32f1
 dirs-$(CONFIG_MACH_STM32F2) += lib/stm32f2
 dirs-$(CONFIG_MACH_STM32F4) += lib/stm32f4
+dirs-$(CONFIG_MACH_STM32G0) += lib/stm32g0
 
 MCU := $(shell echo $(CONFIG_MCU))
 MCU_UPPER := $(shell echo $(CONFIG_MCU) | tr a-z A-Z | tr X x)
@@ -16,6 +17,7 @@ CFLAGS-$(CONFIG_MACH_STM32F0) += -mcpu=cortex-m0 -Ilib/stm32f0/include
 CFLAGS-$(CONFIG_MACH_STM32F1) += -mcpu=cortex-m3 -Ilib/stm32f1/include
 CFLAGS-$(CONFIG_MACH_STM32F2) += -mcpu=cortex-m3 -Ilib/stm32f2/include
 CFLAGS-$(CONFIG_MACH_STM32F4) += -mcpu=cortex-m4 -Ilib/stm32f4/include
+CFLAGS-$(CONFIG_MACH_STM32G0) += -mcpu=cortex-m0plus -Ilib/stm32g0/include
 CFLAGS += $(CFLAGS-y) -D$(MCU_UPPER) -mthumb -Ilib/cmsis-core -Ilib/fast-hash
 
 CFLAGS_canboot.elf += --specs=nano.specs --specs=nosys.specs
@@ -39,6 +41,9 @@ src-$(CONFIG_MACH_STM32F2) += stm32/gpioperiph.c
 src-$(CONFIG_MACH_STM32F4) += ../lib/stm32f4/system_stm32f4xx.c
 src-$(CONFIG_MACH_STM32F4) += stm32/stm32f4.c generic/armcm_timer.c
 src-$(CONFIG_MACH_STM32F4) += stm32/gpioperiph.c
+
+src-$(CONFIG_MACH_STM32G0) += stm32/stm32f0_timer.c
+src-$(CONFIG_MACH_STM32G0) += stm32/stm32g0.c stm32/gpioperiph.c
 
 usb-src-$(CONFIG_HAVE_STM32_USBFS) := stm32/usbfs.c
 usb-src-$(CONFIG_HAVE_STM32_USBOTG) := stm32/usbotg.c

--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -38,15 +38,18 @@ flash_get_page_size(uint32_t addr)
             return 64 * 1024;
         else
             return 128 * 1024;
-    } else if (CONFIG_MACH_STM32F042) {
-        return 1024;
     } else if (CONFIG_MACH_STM32F103) {
         // Check for a 1K page size on the stm32f103
         uint16_t *flash_size = (void*)FLASHSIZE_BASE;
-        if (*flash_size < 256)
+        return *flash_size < 256 ? 1024 : 2 * 1024;
+    } else if (CONFIG_MACH_STM32F0) {
+        if (CONFIG_MACH_STM32F042)
             return 1024;
+        if (CONFIG_MACH_STM32F072)
+            return 2 * 1024;
+        uint16_t *flash_size = (void*)FLASHSIZE_BASE;
+        return *flash_size <= 64 ? 1024 : 2 * 1024;
     }
-    return 2 * 1024;
 }
 
 // Check if the data at the given address has been erased (all 0xff)

--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -10,7 +10,7 @@
 #include "flash.h" // flash_write_block
 #include "internal.h" // FLASH
 
-#if CONFIG_MACH_STM32F4
+#if CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
 #define FLASH_KEY1 (0x45670123UL)
 #define FLASH_KEY2 (0xCDEF89ABUL)
 
@@ -31,7 +31,7 @@ stm32f4_sector_index(uint32_t addr)
 static uint32_t
 flash_get_page_size(uint32_t addr)
 {
-    if (CONFIG_MACH_STM32F4) {
+    if (CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4) {
         if (addr < 0x08010000)
             return 16 * 1024;
         else if (addr < 0x08020000)
@@ -91,7 +91,7 @@ lock_flash(void)
 static void
 erase_page(uint32_t page_address)
 {
-#if CONFIG_MACH_STM32F4
+#if CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
     FLASH->CR = (FLASH_CR_PSIZE_1 | FLASH_CR_STRT | FLASH_CR_SER
                  | ((stm32f4_sector_index(page_address) & 0xF) << 3));
 #else
@@ -106,7 +106,7 @@ erase_page(uint32_t page_address)
 static void
 write_block(uint32_t block_address, uint32_t *data)
 {
-#if CONFIG_MACH_STM32F4
+#if CONFIG_MACH_STM32F2 || CONFIG_MACH_STM32F4
     uint32_t *page = (void*)block_address;
     FLASH->CR = FLASH_CR_PSIZE_1 | FLASH_CR_PG;
     for (int i = 0; i < CONFIG_BLOCK_SIZE / 4; i++) {

--- a/src/stm32/stm32g0.c
+++ b/src/stm32/stm32g0.c
@@ -1,0 +1,133 @@
+// Code to setup clocks on stm32g0
+//
+// Copyright (C) 2019-2021  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_CLOCK_REF_FREQ
+#include "board/armcm_boot.h" // armcm_main
+#include "board/irq.h" // irq_disable
+#include "command.h" // DECL_CONSTANT_STR
+#include "internal.h" // enable_pclock
+#include "sched.h" // sched_main
+
+
+/****************************************************************
+ * Clock setup
+ ****************************************************************/
+
+#define FREQ_PERIPH 64000000
+#define FREQ_USB 48000000
+
+// Map a peripheral address to its enable bits
+struct cline
+lookup_clock_line(uint32_t periph_base)
+{
+    if (periph_base >= IOPORT_BASE) {
+        uint32_t bit = 1 << ((periph_base - IOPORT_BASE) / 0x400);
+        return (struct cline){.en=&RCC->IOPENR, .rst=&RCC->IOPRSTR, .bit=bit};
+    } else if (periph_base >= AHBPERIPH_BASE) {
+        uint32_t bit = 1 << ((periph_base - AHBPERIPH_BASE) / 0x400);
+        return (struct cline){.en=&RCC->AHBENR, .rst=&RCC->AHBRSTR, .bit=bit};
+    }
+    if (periph_base == USB_BASE)
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<13};
+    if (periph_base == CRS_BASE)
+        return (struct cline){.en=&RCC->APBENR1,.rst=&RCC->APBRSTR1,.bit=1<<16};
+    if (periph_base == SPI1_BASE)
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<12};
+    if (periph_base == USART1_BASE)
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<14};
+    if (periph_base == ADC1_BASE)
+        return (struct cline){.en=&RCC->APBENR2,.rst=&RCC->APBRSTR2,.bit=1<<20};
+    uint32_t bit = 1 << ((periph_base - APBPERIPH_BASE) / 0x400);
+    return (struct cline){.en=&RCC->APBENR1, .rst=&RCC->APBRSTR1, .bit=bit};
+}
+
+// Return the frequency of the given peripheral clock
+uint32_t
+get_pclock_frequency(uint32_t periph_base)
+{
+    return FREQ_PERIPH;
+}
+
+// Enable a GPIO peripheral clock
+void
+gpio_clock_enable(GPIO_TypeDef *regs)
+{
+    uint32_t rcc_pos = ((uint32_t)regs - IOPORT_BASE) / 0x400;
+    RCC->IOPENR |= 1 << rcc_pos;
+    RCC->IOPENR;
+}
+
+#if !CONFIG_STM32_CLOCK_REF_INTERNAL
+DECL_CONSTANT_STR("RESERVE_PINS_crystal", "PF0,PF1");
+#endif
+
+// Configure and enable the PLL as clock source
+static void
+clock_setup(void)
+{
+    uint32_t pll_base = 4000000, pll_freq = 192000000, pllcfgr;
+    if (!CONFIG_STM32_CLOCK_REF_INTERNAL) {
+        // Configure PLL from external crystal (HSE)
+        uint32_t div = CONFIG_CLOCK_REF_FREQ / pll_base;
+        RCC->CR |= RCC_CR_HSEON;
+        pllcfgr = RCC_PLLCFGR_PLLSRC_HSE | ((div - 1) << RCC_PLLCFGR_PLLM_Pos);
+    } else {
+        // Configure PLL from internal 16Mhz oscillator (HSI)
+        uint32_t div = 16000000 / pll_base;
+        pllcfgr = RCC_PLLCFGR_PLLSRC_HSI | ((div - 1) << RCC_PLLCFGR_PLLM_Pos);
+    }
+    pllcfgr |= (pll_freq/pll_base) << RCC_PLLCFGR_PLLN_Pos;
+    pllcfgr |= (pll_freq/CONFIG_CLOCK_FREQ - 1) << RCC_PLLCFGR_PLLR_Pos;
+    pllcfgr |= (pll_freq/FREQ_USB - 1) << RCC_PLLCFGR_PLLQ_Pos;
+    RCC->PLLCFGR = pllcfgr | RCC_PLLCFGR_PLLREN | RCC_PLLCFGR_PLLQEN;
+    RCC->CR |= RCC_CR_PLLON;
+
+    // Wait for PLL lock
+    while (!(RCC->CR & RCC_CR_PLLRDY))
+        ;
+
+    // Switch system clock to PLL
+    RCC->CFGR = (2 << RCC_CFGR_SW_Pos);
+    while ((RCC->CFGR & RCC_CFGR_SWS_Msk) != (2 << RCC_CFGR_SWS_Pos))
+        ;
+
+    // Use PLLQCLK for USB (setting USBSEL=2 works in practice)
+    RCC->CCIPR2 = 2 << RCC_CCIPR2_USBSEL_Pos;
+}
+
+
+/****************************************************************
+ * Startup
+ ****************************************************************/
+
+// Main entry point - called from armcm_boot.c:ResetHandler()
+void
+armcm_main(void)
+{
+    SCB->VTOR = (uint32_t)VectorTable;
+
+    // Reset clock registers (in case bootloader has changed them)
+    RCC->CR |= RCC_CR_HSION;
+    while (!(RCC->CR & RCC_CR_HSIRDY))
+        ;
+    RCC->CFGR = 0x00000000;
+    RCC->CR = RCC_CR_HSION;
+    while (RCC->CR & RCC_CR_PLLRDY)
+        ;
+    RCC->PLLCFGR = 0x00001000;
+    RCC->IOPENR = 0x00000000;
+    RCC->AHBENR = 0x00000100;
+    RCC->APBENR1 = 0x00000000;
+    RCC->APBENR2 = 0x00000000;
+
+    // Set flash latency
+    FLASH->ACR = (2<<FLASH_ACR_LATENCY_Pos) | FLASH_ACR_ICEN | FLASH_ACR_PRFTEN;
+
+    // Configure main clock
+    clock_setup();
+
+    sched_main();
+}


### PR DESCRIPTION
This adds support for the stm32g0b1 chip.  I've successfully tested this on my btt-skr-mini-e3-v3.

The stm32f2 flash hardware appears to be identical to stm32f4.  (And, in general, the stm32f2 hardware is very similar to the f4 hardware.)  I don't have an stm32f2, but I think it is safe to enable.

The stm32f070 and stm32f030 appear similar to stm32f103.  I made the minor code changes for it and enabled it.  I don't have these chips, however, so I did not test it.

-Kevin