### PR TITLE
Add support for lpc176x devices

### DIFF
--- a/lib/lpc176x/device/LPC17xx.h
+++ b/lib/lpc176x/device/LPC17xx.h
@@ -1,0 +1,1035 @@
+/**************************************************************************//**
+ * @file     LPC17xx.h
+ * @brief    CMSIS Cortex-M3 Core Peripheral Access Layer Header File for 
+ *           NXP LPC17xx Device Series
+ * @version: V1.09
+ * @date:    17. March 2010
+
+ *
+ * @note
+ * Copyright (C) 2009 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M 
+ * processor based microcontrollers.  This file can be freely distributed 
+ * within development tools that are supporting such ARM based processors. 
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+
+#ifndef __LPC17xx_H__
+#define __LPC17xx_H__
+
+/*
+ * ==========================================================================
+ * ---------- Interrupt Number Definition -----------------------------------
+ * ==========================================================================
+ */
+
+typedef enum IRQn
+{
+/******  Cortex-M3 Processor Exceptions Numbers ***************************************************/
+  NonMaskableInt_IRQn           = -14,      /*!< 2 Non Maskable Interrupt                         */
+  MemoryManagement_IRQn         = -12,      /*!< 4 Cortex-M3 Memory Management Interrupt          */
+  BusFault_IRQn                 = -11,      /*!< 5 Cortex-M3 Bus Fault Interrupt                  */
+  UsageFault_IRQn               = -10,      /*!< 6 Cortex-M3 Usage Fault Interrupt                */
+  SVCall_IRQn                   = -5,       /*!< 11 Cortex-M3 SV Call Interrupt                   */
+  DebugMonitor_IRQn             = -4,       /*!< 12 Cortex-M3 Debug Monitor Interrupt             */
+  PendSV_IRQn                   = -2,       /*!< 14 Cortex-M3 Pend SV Interrupt                   */
+  SysTick_IRQn                  = -1,       /*!< 15 Cortex-M3 System Tick Interrupt               */
+
+/******  LPC17xx Specific Interrupt Numbers *******************************************************/
+  WDT_IRQn                      = 0,        /*!< Watchdog Timer Interrupt                         */
+  TIMER0_IRQn                   = 1,        /*!< Timer0 Interrupt                                 */
+  TIMER1_IRQn                   = 2,        /*!< Timer1 Interrupt                                 */
+  TIMER2_IRQn                   = 3,        /*!< Timer2 Interrupt                                 */
+  TIMER3_IRQn                   = 4,        /*!< Timer3 Interrupt                                 */
+  UART0_IRQn                    = 5,        /*!< UART0 Interrupt                                  */
+  UART1_IRQn                    = 6,        /*!< UART1 Interrupt                                  */
+  UART2_IRQn                    = 7,        /*!< UART2 Interrupt                                  */
+  UART3_IRQn                    = 8,        /*!< UART3 Interrupt                                  */
+  PWM1_IRQn                     = 9,        /*!< PWM1 Interrupt                                   */
+  I2C0_IRQn                     = 10,       /*!< I2C0 Interrupt                                   */
+  I2C1_IRQn                     = 11,       /*!< I2C1 Interrupt                                   */
+  I2C2_IRQn                     = 12,       /*!< I2C2 Interrupt                                   */
+  SPI_IRQn                      = 13,       /*!< SPI Interrupt                                    */
+  SSP0_IRQn                     = 14,       /*!< SSP0 Interrupt                                   */
+  SSP1_IRQn                     = 15,       /*!< SSP1 Interrupt                                   */
+  PLL0_IRQn                     = 16,       /*!< PLL0 Lock (Main PLL) Interrupt                   */
+  RTC_IRQn                      = 17,       /*!< Real Time Clock Interrupt                        */
+  EINT0_IRQn                    = 18,       /*!< External Interrupt 0 Interrupt                   */
+  EINT1_IRQn                    = 19,       /*!< External Interrupt 1 Interrupt                   */
+  EINT2_IRQn                    = 20,       /*!< External Interrupt 2 Interrupt                   */
+  EINT3_IRQn                    = 21,       /*!< External Interrupt 3 Interrupt                   */
+  ADC_IRQn                      = 22,       /*!< A/D Converter Interrupt                          */
+  BOD_IRQn                      = 23,       /*!< Brown-Out Detect Interrupt                       */
+  USB_IRQn                      = 24,       /*!< USB Interrupt                                    */
+  CAN_IRQn                      = 25,       /*!< CAN Interrupt                                    */
+  DMA_IRQn                      = 26,       /*!< General Purpose DMA Interrupt                    */
+  I2S_IRQn                      = 27,       /*!< I2S Interrupt                                    */
+  ENET_IRQn                     = 28,       /*!< Ethernet Interrupt                               */
+  RIT_IRQn                      = 29,       /*!< Repetitive Interrupt Timer Interrupt             */
+  MCPWM_IRQn                    = 30,       /*!< Motor Control PWM Interrupt                      */
+  QEI_IRQn                      = 31,       /*!< Quadrature Encoder Interface Interrupt           */
+  PLL1_IRQn                     = 32,       /*!< PLL1 Lock (USB PLL) Interrupt                    */
+  USBActivity_IRQn              = 33,       /* USB Activity interrupt                             */
+  CANActivity_IRQn              = 34,       /* CAN Activity interrupt                             */
+} IRQn_Type;
+
+
+/*
+ * ==========================================================================
+ * ----------- Processor and Core Peripheral Section ------------------------
+ * ==========================================================================
+ */
+
+/* Configuration of the Cortex-M3 Processor and Core Peripherals */
+#define __MPU_PRESENT             1         /*!< MPU present or not                               */
+#define __NVIC_PRIO_BITS          5         /*!< Number of Bits used for Priority Levels          */
+#define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
+
+
+#include "core_cm3.h"                       /* Cortex-M3 processor and core peripherals           */
+#include "system_LPC17xx.h"                 /* System Header                                      */
+
+
+/******************************************************************************/
+/*                Device Specific Peripheral registers structures             */
+/******************************************************************************/
+
+#if defined ( __CC_ARM   )
+#pragma anon_unions
+#endif
+
+/*------------- System Control (SC) ------------------------------------------*/
+typedef struct
+{
+  __IO uint32_t FLASHCFG;               /* Flash Accelerator Module           */
+       uint32_t RESERVED0[31];
+  __IO uint32_t PLL0CON;                /* Clocking and Power Control         */
+  __IO uint32_t PLL0CFG;
+  __I  uint32_t PLL0STAT;
+  __O  uint32_t PLL0FEED;
+       uint32_t RESERVED1[4];
+  __IO uint32_t PLL1CON;
+  __IO uint32_t PLL1CFG;
+  __I  uint32_t PLL1STAT;
+  __O  uint32_t PLL1FEED;
+       uint32_t RESERVED2[4];
+  __IO uint32_t PCON;
+  __IO uint32_t PCONP;
+       uint32_t RESERVED3[15];
+  __IO uint32_t CCLKCFG;
+  __IO uint32_t USBCLKCFG;
+  __IO uint32_t CLKSRCSEL;
+  __IO uint32_t	CANSLEEPCLR;
+  __IO uint32_t	CANWAKEFLAGS;
+       uint32_t RESERVED4[10];
+  __IO uint32_t EXTINT;                 /* External Interrupts                */
+       uint32_t RESERVED5;
+  __IO uint32_t EXTMODE;
+  __IO uint32_t EXTPOLAR;
+       uint32_t RESERVED6[12];
+  __IO uint32_t RSID;                   /* Reset                              */
+       uint32_t RESERVED7[7];
+  __IO uint32_t SCS;                    /* Syscon Miscellaneous Registers     */
+  __IO uint32_t IRCTRIM;                /* Clock Dividers                     */
+  __IO uint32_t PCLKSEL0;
+  __IO uint32_t PCLKSEL1;
+       uint32_t RESERVED8[4];
+  __IO uint32_t USBIntSt;               /* USB Device/OTG Interrupt Register  */
+  __IO uint32_t DMAREQSEL;
+  __IO uint32_t CLKOUTCFG;              /* Clock Output Configuration         */
+ } LPC_SC_TypeDef;
+
+/*------------- Pin Connect Block (PINCON) -----------------------------------*/
+typedef struct
+{
+  __IO uint32_t PINSEL0;
+  __IO uint32_t PINSEL1;
+  __IO uint32_t PINSEL2;
+  __IO uint32_t PINSEL3;
+  __IO uint32_t PINSEL4;
+  __IO uint32_t PINSEL5;
+  __IO uint32_t PINSEL6;
+  __IO uint32_t PINSEL7;
+  __IO uint32_t PINSEL8;
+  __IO uint32_t PINSEL9;
+  __IO uint32_t PINSEL10;
+       uint32_t RESERVED0[5];
+  __IO uint32_t PINMODE0;
+  __IO uint32_t PINMODE1;
+  __IO uint32_t PINMODE2;
+  __IO uint32_t PINMODE3;
+  __IO uint32_t PINMODE4;
+  __IO uint32_t PINMODE5;
+  __IO uint32_t PINMODE6;
+  __IO uint32_t PINMODE7;
+  __IO uint32_t PINMODE8;
+  __IO uint32_t PINMODE9;
+  __IO uint32_t PINMODE_OD0;
+  __IO uint32_t PINMODE_OD1;
+  __IO uint32_t PINMODE_OD2;
+  __IO uint32_t PINMODE_OD3;
+  __IO uint32_t PINMODE_OD4;
+  __IO uint32_t I2CPADCFG;
+} LPC_PINCON_TypeDef;
+
+/*------------- General Purpose Input/Output (GPIO) --------------------------*/
+typedef struct
+{
+  union {
+    __IO uint32_t FIODIR;
+    struct {
+      __IO uint16_t FIODIRL;
+      __IO uint16_t FIODIRH;
+    };
+    struct {
+      __IO uint8_t  FIODIR0;
+      __IO uint8_t  FIODIR1;
+      __IO uint8_t  FIODIR2;
+      __IO uint8_t  FIODIR3;
+    };
+  };
+  uint32_t RESERVED0[3];
+  union {
+    __IO uint32_t FIOMASK;
+    struct {
+      __IO uint16_t FIOMASKL;
+      __IO uint16_t FIOMASKH;
+    };
+    struct {
+      __IO uint8_t  FIOMASK0;
+      __IO uint8_t  FIOMASK1;
+      __IO uint8_t  FIOMASK2;
+      __IO uint8_t  FIOMASK3;
+    };
+  };
+  union {
+    __IO uint32_t FIOPIN;
+    struct {
+      __IO uint16_t FIOPINL;
+      __IO uint16_t FIOPINH;
+    };
+    struct {
+      __IO uint8_t  FIOPIN0;
+      __IO uint8_t  FIOPIN1;
+      __IO uint8_t  FIOPIN2;
+      __IO uint8_t  FIOPIN3;
+    };
+  };
+  union {
+    __IO uint32_t FIOSET;
+    struct {
+      __IO uint16_t FIOSETL;
+      __IO uint16_t FIOSETH;
+    };
+    struct {
+      __IO uint8_t  FIOSET0;
+      __IO uint8_t  FIOSET1;
+      __IO uint8_t  FIOSET2;
+      __IO uint8_t  FIOSET3;
+    };
+  };
+  union {
+    __O  uint32_t FIOCLR;
+    struct {
+      __O  uint16_t FIOCLRL;
+      __O  uint16_t FIOCLRH;
+    };
+    struct {
+      __O  uint8_t  FIOCLR0;
+      __O  uint8_t  FIOCLR1;
+      __O  uint8_t  FIOCLR2;
+      __O  uint8_t  FIOCLR3;
+    };
+  };
+} LPC_GPIO_TypeDef;
+
+typedef struct
+{
+  __I  uint32_t IntStatus;
+  __I  uint32_t IO0IntStatR;
+  __I  uint32_t IO0IntStatF;
+  __O  uint32_t IO0IntClr;
+  __IO uint32_t IO0IntEnR;
+  __IO uint32_t IO0IntEnF;
+       uint32_t RESERVED0[3];
+  __I  uint32_t IO2IntStatR;
+  __I  uint32_t IO2IntStatF;
+  __O  uint32_t IO2IntClr;
+  __IO uint32_t IO2IntEnR;
+  __IO uint32_t IO2IntEnF;
+} LPC_GPIOINT_TypeDef;
+
+/*------------- Timer (TIM) --------------------------------------------------*/
+typedef struct
+{
+  __IO uint32_t IR;
+  __IO uint32_t TCR;
+  __IO uint32_t TC;
+  __IO uint32_t PR;
+  __IO uint32_t PC;
+  __IO uint32_t MCR;
+  __IO uint32_t MR0;
+  __IO uint32_t MR1;
+  __IO uint32_t MR2;
+  __IO uint32_t MR3;
+  __IO uint32_t CCR;
+  __I  uint32_t CR0;
+  __I  uint32_t CR1;
+       uint32_t RESERVED0[2];
+  __IO uint32_t EMR;
+       uint32_t RESERVED1[12];
+  __IO uint32_t CTCR;
+} LPC_TIM_TypeDef;
+
+/*------------- Pulse-Width Modulation (PWM) ---------------------------------*/
+typedef struct
+{
+  __IO uint32_t IR;
+  __IO uint32_t TCR;
+  __IO uint32_t TC;
+  __IO uint32_t PR;
+  __IO uint32_t PC;
+  __IO uint32_t MCR;
+  __IO uint32_t MR0;
+  __IO uint32_t MR1;
+  __IO uint32_t MR2;
+  __IO uint32_t MR3;
+  __IO uint32_t CCR;
+  __I  uint32_t CR0;
+  __I  uint32_t CR1;
+  __I  uint32_t CR2;
+  __I  uint32_t CR3;
+       uint32_t RESERVED0;
+  __IO uint32_t MR4;
+  __IO uint32_t MR5;
+  __IO uint32_t MR6;
+  __IO uint32_t PCR;
+  __IO uint32_t LER;
+       uint32_t RESERVED1[7];
+  __IO uint32_t CTCR;
+} LPC_PWM_TypeDef;
+
+/*------------- Universal Asynchronous Receiver Transmitter (UART) -----------*/
+typedef struct
+{
+  union {
+  __I  uint8_t  RBR;
+  __O  uint8_t  THR;
+  __IO uint8_t  DLL;
+       uint32_t RESERVED0;
+  };
+  union {
+  __IO uint8_t  DLM;
+  __IO uint32_t IER;
+  };
+  union {
+  __I  uint32_t IIR;
+  __O  uint8_t  FCR;
+  };
+  __IO uint8_t  LCR;
+       uint8_t  RESERVED1[7];
+  __I  uint8_t  LSR;
+       uint8_t  RESERVED2[7];
+  __IO uint8_t  SCR;
+       uint8_t  RESERVED3[3];
+  __IO uint32_t ACR;
+  __IO uint8_t  ICR;
+       uint8_t  RESERVED4[3];
+  __IO uint8_t  FDR;
+       uint8_t  RESERVED5[7];
+  __IO uint8_t  TER;
+       uint8_t  RESERVED6[39];
+  __IO uint32_t FIFOLVL;
+} LPC_UART_TypeDef;
+
+typedef struct
+{
+  union {
+  __I  uint8_t  RBR;
+  __O  uint8_t  THR;
+  __IO uint8_t  DLL;
+       uint32_t RESERVED0;
+  };
+  union {
+  __IO uint8_t  DLM;
+  __IO uint32_t IER;
+  };
+  union {
+  __I  uint32_t IIR;
+  __O  uint8_t  FCR;
+  };
+  __IO uint8_t  LCR;
+       uint8_t  RESERVED1[7];
+  __I  uint8_t  LSR;
+       uint8_t  RESERVED2[7];
+  __IO uint8_t  SCR;
+       uint8_t  RESERVED3[3];
+  __IO uint32_t ACR;
+  __IO uint8_t  ICR;
+       uint8_t  RESERVED4[3];
+  __IO uint8_t  FDR;
+       uint8_t  RESERVED5[7];
+  __IO uint8_t  TER;
+       uint8_t  RESERVED6[39];
+  __IO uint32_t FIFOLVL;
+} LPC_UART0_TypeDef;
+
+typedef struct
+{
+  union {
+  __I  uint8_t  RBR;
+  __O  uint8_t  THR;
+  __IO uint8_t  DLL;
+       uint32_t RESERVED0;
+  };
+  union {
+  __IO uint8_t  DLM;
+  __IO uint32_t IER;
+  };
+  union {
+  __I  uint32_t IIR;
+  __O  uint8_t  FCR;
+  };
+  __IO uint8_t  LCR;
+       uint8_t  RESERVED1[3];
+  __IO uint8_t  MCR;
+       uint8_t  RESERVED2[3];
+  __I  uint8_t  LSR;
+       uint8_t  RESERVED3[3];
+  __I  uint8_t  MSR;
+       uint8_t  RESERVED4[3];
+  __IO uint8_t  SCR;
+       uint8_t  RESERVED5[3];
+  __IO uint32_t ACR;
+       uint32_t RESERVED6;
+  __IO uint32_t FDR;
+       uint32_t RESERVED7;
+  __IO uint8_t  TER;
+       uint8_t  RESERVED8[27];
+  __IO uint8_t  RS485CTRL;
+       uint8_t  RESERVED9[3];
+  __IO uint8_t  ADRMATCH;
+       uint8_t  RESERVED10[3];
+  __IO uint8_t  RS485DLY;
+       uint8_t  RESERVED11[3];
+  __IO uint32_t FIFOLVL;
+} LPC_UART1_TypeDef;
+
+/*------------- Serial Peripheral Interface (SPI) ----------------------------*/
+typedef struct
+{
+  __IO uint32_t SPCR;
+  __I  uint32_t SPSR;
+  __IO uint32_t SPDR;
+  __IO uint32_t SPCCR;
+       uint32_t RESERVED0[3];
+  __IO uint32_t SPINT;
+} LPC_SPI_TypeDef;
+
+/*------------- Synchronous Serial Communication (SSP) -----------------------*/
+typedef struct
+{
+  __IO uint32_t CR0;
+  __IO uint32_t CR1;
+  __IO uint32_t DR;
+  __I  uint32_t SR;
+  __IO uint32_t CPSR;
+  __IO uint32_t IMSC;
+  __IO uint32_t RIS;
+  __IO uint32_t MIS;
+  __IO uint32_t ICR;
+  __IO uint32_t DMACR;
+} LPC_SSP_TypeDef;
+
+/*------------- Inter-Integrated Circuit (I2C) -------------------------------*/
+typedef struct
+{
+  __IO uint32_t I2CONSET;
+  __I  uint32_t I2STAT;
+  __IO uint32_t I2DAT;
+  __IO uint32_t I2ADR0;
+  __IO uint32_t I2SCLH;
+  __IO uint32_t I2SCLL;
+  __O  uint32_t I2CONCLR;
+  __IO uint32_t MMCTRL;
+  __IO uint32_t I2ADR1;
+  __IO uint32_t I2ADR2;
+  __IO uint32_t I2ADR3;
+  __I  uint32_t I2DATA_BUFFER;
+  __IO uint32_t I2MASK0;
+  __IO uint32_t I2MASK1;
+  __IO uint32_t I2MASK2;
+  __IO uint32_t I2MASK3;
+} LPC_I2C_TypeDef;
+
+/*------------- Inter IC Sound (I2S) -----------------------------------------*/
+typedef struct
+{
+  __IO uint32_t I2SDAO;
+  __IO uint32_t I2SDAI;
+  __O  uint32_t I2STXFIFO;
+  __I  uint32_t I2SRXFIFO;
+  __I  uint32_t I2SSTATE;
+  __IO uint32_t I2SDMA1;
+  __IO uint32_t I2SDMA2;
+  __IO uint32_t I2SIRQ;
+  __IO uint32_t I2STXRATE;
+  __IO uint32_t I2SRXRATE;
+  __IO uint32_t I2STXBITRATE;
+  __IO uint32_t I2SRXBITRATE;
+  __IO uint32_t I2STXMODE;
+  __IO uint32_t I2SRXMODE;
+} LPC_I2S_TypeDef;
+
+/*------------- Repetitive Interrupt Timer (RIT) -----------------------------*/
+typedef struct
+{
+  __IO uint32_t RICOMPVAL;
+  __IO uint32_t RIMASK;
+  __IO uint8_t  RICTRL;
+       uint8_t  RESERVED0[3];
+  __IO uint32_t RICOUNTER;
+} LPC_RIT_TypeDef;
+
+/*------------- Real-Time Clock (RTC) ----------------------------------------*/
+typedef struct
+{
+  __IO uint8_t  ILR;
+       uint8_t  RESERVED0[7];
+  __IO uint8_t  CCR;
+       uint8_t  RESERVED1[3];
+  __IO uint8_t  CIIR;
+       uint8_t  RESERVED2[3];
+  __IO uint8_t  AMR;
+       uint8_t  RESERVED3[3];
+  __I  uint32_t CTIME0;
+  __I  uint32_t CTIME1;
+  __I  uint32_t CTIME2;
+  __IO uint8_t  SEC;
+       uint8_t  RESERVED4[3];
+  __IO uint8_t  MIN;
+       uint8_t  RESERVED5[3];
+  __IO uint8_t  HOUR;
+       uint8_t  RESERVED6[3];
+  __IO uint8_t  DOM;
+       uint8_t  RESERVED7[3];
+  __IO uint8_t  DOW;
+       uint8_t  RESERVED8[3];
+  __IO uint16_t DOY;
+       uint16_t RESERVED9;
+  __IO uint8_t  MONTH;
+       uint8_t  RESERVED10[3];
+  __IO uint16_t YEAR;
+       uint16_t RESERVED11;
+  __IO uint32_t CALIBRATION;
+  __IO uint32_t GPREG0;
+  __IO uint32_t GPREG1;
+  __IO uint32_t GPREG2;
+  __IO uint32_t GPREG3;
+  __IO uint32_t GPREG4;
+  __IO uint8_t  RTC_AUXEN;
+       uint8_t  RESERVED12[3];
+  __IO uint8_t  RTC_AUX;
+       uint8_t  RESERVED13[3];
+  __IO uint8_t  ALSEC;
+       uint8_t  RESERVED14[3];
+  __IO uint8_t  ALMIN;
+       uint8_t  RESERVED15[3];
+  __IO uint8_t  ALHOUR;
+       uint8_t  RESERVED16[3];
+  __IO uint8_t  ALDOM;
+       uint8_t  RESERVED17[3];
+  __IO uint8_t  ALDOW;
+       uint8_t  RESERVED18[3];
+  __IO uint16_t ALDOY;
+       uint16_t RESERVED19;
+  __IO uint8_t  ALMON;
+       uint8_t  RESERVED20[3];
+  __IO uint16_t ALYEAR;
+       uint16_t RESERVED21;
+} LPC_RTC_TypeDef;
+
+/*------------- Watchdog Timer (WDT) -----------------------------------------*/
+typedef struct
+{
+  __IO uint8_t  WDMOD;
+       uint8_t  RESERVED0[3];
+  __IO uint32_t WDTC;
+  __O  uint8_t  WDFEED;
+       uint8_t  RESERVED1[3];
+  __I  uint32_t WDTV;
+  __IO uint32_t WDCLKSEL;
+} LPC_WDT_TypeDef;
+
+/*------------- Analog-to-Digital Converter (ADC) ----------------------------*/
+typedef struct
+{
+  __IO uint32_t ADCR;
+  __IO uint32_t ADGDR;
+       uint32_t RESERVED0;
+  __IO uint32_t ADINTEN;
+  __I  uint32_t ADDR0;
+  __I  uint32_t ADDR1;
+  __I  uint32_t ADDR2;
+  __I  uint32_t ADDR3;
+  __I  uint32_t ADDR4;
+  __I  uint32_t ADDR5;
+  __I  uint32_t ADDR6;
+  __I  uint32_t ADDR7;
+  __I  uint32_t ADSTAT;
+  __IO uint32_t ADTRM;
+} LPC_ADC_TypeDef;
+
+/*------------- Digital-to-Analog Converter (DAC) ----------------------------*/
+typedef struct
+{
+  __IO uint32_t DACR;
+  __IO uint32_t DACCTRL;
+  __IO uint16_t DACCNTVAL;
+} LPC_DAC_TypeDef;
+
+/*------------- Motor Control Pulse-Width Modulation (MCPWM) -----------------*/
+typedef struct
+{
+  __I  uint32_t MCCON;
+  __O  uint32_t MCCON_SET;
+  __O  uint32_t MCCON_CLR;
+  __I  uint32_t MCCAPCON;
+  __O  uint32_t MCCAPCON_SET;
+  __O  uint32_t MCCAPCON_CLR;
+  __IO uint32_t MCTIM0;
+  __IO uint32_t MCTIM1;
+  __IO uint32_t MCTIM2;
+  __IO uint32_t MCPER0;
+  __IO uint32_t MCPER1;
+  __IO uint32_t MCPER2;
+  __IO uint32_t MCPW0;
+  __IO uint32_t MCPW1;
+  __IO uint32_t MCPW2;
+  __IO uint32_t MCDEADTIME;
+  __IO uint32_t MCCCP;
+  __IO uint32_t MCCR0;
+  __IO uint32_t MCCR1;
+  __IO uint32_t MCCR2;
+  __I  uint32_t MCINTEN;
+  __O  uint32_t MCINTEN_SET;
+  __O  uint32_t MCINTEN_CLR;
+  __I  uint32_t MCCNTCON;
+  __O  uint32_t MCCNTCON_SET;
+  __O  uint32_t MCCNTCON_CLR;
+  __I  uint32_t MCINTFLAG;
+  __O  uint32_t MCINTFLAG_SET;
+  __O  uint32_t MCINTFLAG_CLR;
+  __O  uint32_t MCCAP_CLR;
+} LPC_MCPWM_TypeDef;
+
+/*------------- Quadrature Encoder Interface (QEI) ---------------------------*/
+typedef struct
+{
+  __O  uint32_t QEICON;
+  __I  uint32_t QEISTAT;
+  __IO uint32_t QEICONF;
+  __I  uint32_t QEIPOS;
+  __IO uint32_t QEIMAXPOS;
+  __IO uint32_t CMPOS0;
+  __IO uint32_t CMPOS1;
+  __IO uint32_t CMPOS2;
+  __I  uint32_t INXCNT;
+  __IO uint32_t INXCMP;
+  __IO uint32_t QEILOAD;
+  __I  uint32_t QEITIME;
+  __I  uint32_t QEIVEL;
+  __I  uint32_t QEICAP;
+  __IO uint32_t VELCOMP;
+  __IO uint32_t FILTER;
+       uint32_t RESERVED0[998];
+  __O  uint32_t QEIIEC;
+  __O  uint32_t QEIIES;
+  __I  uint32_t QEIINTSTAT;
+  __I  uint32_t QEIIE;
+  __O  uint32_t QEICLR;
+  __O  uint32_t QEISET;
+} LPC_QEI_TypeDef;
+
+/*------------- Controller Area Network (CAN) --------------------------------*/
+typedef struct
+{
+  __IO uint32_t mask[512];              /* ID Masks                           */
+} LPC_CANAF_RAM_TypeDef;
+
+typedef struct                          /* Acceptance Filter Registers        */
+{
+  __IO uint32_t AFMR;
+  __IO uint32_t SFF_sa;
+  __IO uint32_t SFF_GRP_sa;
+  __IO uint32_t EFF_sa;
+  __IO uint32_t EFF_GRP_sa;
+  __IO uint32_t ENDofTable;
+  __I  uint32_t LUTerrAd;
+  __I  uint32_t LUTerr;
+  __IO uint32_t FCANIE;
+  __IO uint32_t FCANIC0;
+  __IO uint32_t FCANIC1;
+} LPC_CANAF_TypeDef;
+
+typedef struct                          /* Central Registers                  */
+{
+  __I  uint32_t CANTxSR;
+  __I  uint32_t CANRxSR;
+  __I  uint32_t CANMSR;
+} LPC_CANCR_TypeDef;
+
+typedef struct                          /* Controller Registers               */
+{
+  __IO uint32_t MOD;
+  __O  uint32_t CMR;
+  __IO uint32_t GSR;
+  __I  uint32_t ICR;
+  __IO uint32_t IER;
+  __IO uint32_t BTR;
+  __IO uint32_t EWL;
+  __I  uint32_t SR;
+  __IO uint32_t RFS;
+  __IO uint32_t RID;
+  __IO uint32_t RDA;
+  __IO uint32_t RDB;
+  __IO uint32_t TFI1;
+  __IO uint32_t TID1;
+  __IO uint32_t TDA1;
+  __IO uint32_t TDB1;
+  __IO uint32_t TFI2;
+  __IO uint32_t TID2;
+  __IO uint32_t TDA2;
+  __IO uint32_t TDB2;
+  __IO uint32_t TFI3;
+  __IO uint32_t TID3;
+  __IO uint32_t TDA3;
+  __IO uint32_t TDB3;
+} LPC_CAN_TypeDef;
+
+/*------------- General Purpose Direct Memory Access (GPDMA) -----------------*/
+typedef struct                          /* Common Registers                   */
+{
+  __I  uint32_t DMACIntStat;
+  __I  uint32_t DMACIntTCStat;
+  __O  uint32_t DMACIntTCClear;
+  __I  uint32_t DMACIntErrStat;
+  __O  uint32_t DMACIntErrClr;
+  __I  uint32_t DMACRawIntTCStat;
+  __I  uint32_t DMACRawIntErrStat;
+  __I  uint32_t DMACEnbldChns;
+  __IO uint32_t DMACSoftBReq;
+  __IO uint32_t DMACSoftSReq;
+  __IO uint32_t DMACSoftLBReq;
+  __IO uint32_t DMACSoftLSReq;
+  __IO uint32_t DMACConfig;
+  __IO uint32_t DMACSync;
+} LPC_GPDMA_TypeDef;
+
+typedef struct                          /* Channel Registers                  */
+{
+  __IO uint32_t DMACCSrcAddr;
+  __IO uint32_t DMACCDestAddr;
+  __IO uint32_t DMACCLLI;
+  __IO uint32_t DMACCControl;
+  __IO uint32_t DMACCConfig;
+} LPC_GPDMACH_TypeDef;
+
+/*------------- Universal Serial Bus (USB) -----------------------------------*/
+typedef struct
+{
+  __I  uint32_t HcRevision;             /* USB Host Registers                 */
+  __IO uint32_t HcControl;
+  __IO uint32_t HcCommandStatus;
+  __IO uint32_t HcInterruptStatus;
+  __IO uint32_t HcInterruptEnable;
+  __IO uint32_t HcInterruptDisable;
+  __IO uint32_t HcHCCA;
+  __I  uint32_t HcPeriodCurrentED;
+  __IO uint32_t HcControlHeadED;
+  __IO uint32_t HcControlCurrentED;
+  __IO uint32_t HcBulkHeadED;
+  __IO uint32_t HcBulkCurrentED;
+  __I  uint32_t HcDoneHead;
+  __IO uint32_t HcFmInterval;
+  __I  uint32_t HcFmRemaining;
+  __I  uint32_t HcFmNumber;
+  __IO uint32_t HcPeriodicStart;
+  __IO uint32_t HcLSTreshold;
+  __IO uint32_t HcRhDescriptorA;
+  __IO uint32_t HcRhDescriptorB;
+  __IO uint32_t HcRhStatus;
+  __IO uint32_t HcRhPortStatus1;
+  __IO uint32_t HcRhPortStatus2;
+       uint32_t RESERVED0[40];
+  __I  uint32_t Module_ID;
+
+  __I  uint32_t OTGIntSt;               /* USB On-The-Go Registers            */
+  __IO uint32_t OTGIntEn;
+  __O  uint32_t OTGIntSet;
+  __O  uint32_t OTGIntClr;
+  __IO uint32_t OTGStCtrl;
+  __IO uint32_t OTGTmr;
+       uint32_t RESERVED1[58];
+
+  __I  uint32_t USBDevIntSt;            /* USB Device Interrupt Registers     */
+  __IO uint32_t USBDevIntEn;
+  __O  uint32_t USBDevIntClr;
+  __O  uint32_t USBDevIntSet;
+
+  __O  uint32_t USBCmdCode;             /* USB Device SIE Command Registers   */
+  __I  uint32_t USBCmdData;
+
+  __I  uint32_t USBRxData;              /* USB Device Transfer Registers      */
+  __O  uint32_t USBTxData;
+  __I  uint32_t USBRxPLen;
+  __O  uint32_t USBTxPLen;
+  __IO uint32_t USBCtrl;
+  __O  uint32_t USBDevIntPri;
+
+  __I  uint32_t USBEpIntSt;             /* USB Device Endpoint Interrupt Regs */
+  __IO uint32_t USBEpIntEn;
+  __O  uint32_t USBEpIntClr;
+  __O  uint32_t USBEpIntSet;
+  __O  uint32_t USBEpIntPri;
+
+  __IO uint32_t USBReEp;                /* USB Device Endpoint Realization Reg*/
+  __O  uint32_t USBEpInd;
+  __IO uint32_t USBMaxPSize;
+
+  __I  uint32_t USBDMARSt;              /* USB Device DMA Registers           */
+  __O  uint32_t USBDMARClr;
+  __O  uint32_t USBDMARSet;
+       uint32_t RESERVED2[9];
+  __IO uint32_t USBUDCAH;
+  __I  uint32_t USBEpDMASt;
+  __O  uint32_t USBEpDMAEn;
+  __O  uint32_t USBEpDMADis;
+  __I  uint32_t USBDMAIntSt;
+  __IO uint32_t USBDMAIntEn;
+       uint32_t RESERVED3[2];
+  __I  uint32_t USBEoTIntSt;
+  __O  uint32_t USBEoTIntClr;
+  __O  uint32_t USBEoTIntSet;
+  __I  uint32_t USBNDDRIntSt;
+  __O  uint32_t USBNDDRIntClr;
+  __O  uint32_t USBNDDRIntSet;
+  __I  uint32_t USBSysErrIntSt;
+  __O  uint32_t USBSysErrIntClr;
+  __O  uint32_t USBSysErrIntSet;
+       uint32_t RESERVED4[15];
+
+  union {
+  __I  uint32_t I2C_RX;                 /* USB OTG I2C Registers              */
+  __O  uint32_t I2C_TX;
+  };
+  __I  uint32_t I2C_STS;
+  __IO uint32_t I2C_CTL;
+  __IO uint32_t I2C_CLKHI;
+  __O  uint32_t I2C_CLKLO;
+       uint32_t RESERVED5[824];
+
+  union {
+  __IO uint32_t USBClkCtrl;             /* USB Clock Control Registers        */
+  __IO uint32_t OTGClkCtrl;
+  };
+  union {
+  __I  uint32_t USBClkSt;
+  __I  uint32_t OTGClkSt;
+  };
+} LPC_USB_TypeDef;
+
+/*------------- Ethernet Media Access Controller (EMAC) ----------------------*/
+typedef struct
+{
+  __IO uint32_t MAC1;                   /* MAC Registers                      */
+  __IO uint32_t MAC2;
+  __IO uint32_t IPGT;
+  __IO uint32_t IPGR;
+  __IO uint32_t CLRT;
+  __IO uint32_t MAXF;
+  __IO uint32_t SUPP;
+  __IO uint32_t TEST;
+  __IO uint32_t MCFG;
+  __IO uint32_t MCMD;
+  __IO uint32_t MADR;
+  __O  uint32_t MWTD;
+  __I  uint32_t MRDD;
+  __I  uint32_t MIND;
+       uint32_t RESERVED0[2];
+  __IO uint32_t SA0;
+  __IO uint32_t SA1;
+  __IO uint32_t SA2;
+       uint32_t RESERVED1[45];
+  __IO uint32_t Command;                /* Control Registers                  */
+  __I  uint32_t Status;
+  __IO uint32_t RxDescriptor;
+  __IO uint32_t RxStatus;
+  __IO uint32_t RxDescriptorNumber;
+  __I  uint32_t RxProduceIndex;
+  __IO uint32_t RxConsumeIndex;
+  __IO uint32_t TxDescriptor;
+  __IO uint32_t TxStatus;
+  __IO uint32_t TxDescriptorNumber;
+  __IO uint32_t TxProduceIndex;
+  __I  uint32_t TxConsumeIndex;
+       uint32_t RESERVED2[10];
+  __I  uint32_t TSV0;
+  __I  uint32_t TSV1;
+  __I  uint32_t RSV;
+       uint32_t RESERVED3[3];
+  __IO uint32_t FlowControlCounter;
+  __I  uint32_t FlowControlStatus;
+       uint32_t RESERVED4[34];
+  __IO uint32_t RxFilterCtrl;           /* Rx Filter Registers                */
+  __IO uint32_t RxFilterWoLStatus;
+  __IO uint32_t RxFilterWoLClear;
+       uint32_t RESERVED5;
+  __IO uint32_t HashFilterL;
+  __IO uint32_t HashFilterH;
+       uint32_t RESERVED6[882];
+  __I  uint32_t IntStatus;              /* Module Control Registers           */
+  __IO uint32_t IntEnable;
+  __O  uint32_t IntClear;
+  __O  uint32_t IntSet;
+       uint32_t RESERVED7;
+  __IO uint32_t PowerDown;
+       uint32_t RESERVED8;
+  __IO uint32_t Module_ID;
+} LPC_EMAC_TypeDef;
+
+#if defined ( __CC_ARM   )
+#pragma no_anon_unions
+#endif
+
+
+/******************************************************************************/
+/*                         Peripheral memory map                              */
+/******************************************************************************/
+/* Base addresses                                                             */
+#define LPC_FLASH_BASE        (0x00000000UL)
+#define LPC_RAM_BASE          (0x10000000UL)
+#define LPC_GPIO_BASE         (0x2009C000UL)
+#define LPC_APB0_BASE         (0x40000000UL)
+#define LPC_APB1_BASE         (0x40080000UL)
+#define LPC_AHB_BASE          (0x50000000UL)
+#define LPC_CM3_BASE          (0xE0000000UL)
+
+/* APB0 peripherals                                                           */
+#define LPC_WDT_BASE          (LPC_APB0_BASE + 0x00000)
+#define LPC_TIM0_BASE         (LPC_APB0_BASE + 0x04000)
+#define LPC_TIM1_BASE         (LPC_APB0_BASE + 0x08000)
+#define LPC_UART0_BASE        (LPC_APB0_BASE + 0x0C000)
+#define LPC_UART1_BASE        (LPC_APB0_BASE + 0x10000)
+#define LPC_PWM1_BASE         (LPC_APB0_BASE + 0x18000)
+#define LPC_I2C0_BASE         (LPC_APB0_BASE + 0x1C000)
+#define LPC_SPI_BASE          (LPC_APB0_BASE + 0x20000)
+#define LPC_RTC_BASE          (LPC_APB0_BASE + 0x24000)
+#define LPC_GPIOINT_BASE      (LPC_APB0_BASE + 0x28080)
+#define LPC_PINCON_BASE       (LPC_APB0_BASE + 0x2C000)
+#define LPC_SSP1_BASE         (LPC_APB0_BASE + 0x30000)
+#define LPC_ADC_BASE          (LPC_APB0_BASE + 0x34000)
+#define LPC_CANAF_RAM_BASE    (LPC_APB0_BASE + 0x38000)
+#define LPC_CANAF_BASE        (LPC_APB0_BASE + 0x3C000)
+#define LPC_CANCR_BASE        (LPC_APB0_BASE + 0x40000)
+#define LPC_CAN1_BASE         (LPC_APB0_BASE + 0x44000)
+#define LPC_CAN2_BASE         (LPC_APB0_BASE + 0x48000)
+#define LPC_I2C1_BASE         (LPC_APB0_BASE + 0x5C000)
+
+/* APB1 peripherals                                                           */
+#define LPC_SSP0_BASE         (LPC_APB1_BASE + 0x08000)
+#define LPC_DAC_BASE          (LPC_APB1_BASE + 0x0C000)
+#define LPC_TIM2_BASE         (LPC_APB1_BASE + 0x10000)
+#define LPC_TIM3_BASE         (LPC_APB1_BASE + 0x14000)
+#define LPC_UART2_BASE        (LPC_APB1_BASE + 0x18000)
+#define LPC_UART3_BASE        (LPC_APB1_BASE + 0x1C000)
+#define LPC_I2C2_BASE         (LPC_APB1_BASE + 0x20000)
+#define LPC_I2S_BASE          (LPC_APB1_BASE + 0x28000)
+#define LPC_RIT_BASE          (LPC_APB1_BASE + 0x30000)
+#define LPC_MCPWM_BASE        (LPC_APB1_BASE + 0x38000)
+#define LPC_QEI_BASE          (LPC_APB1_BASE + 0x3C000)
+#define LPC_SC_BASE           (LPC_APB1_BASE + 0x7C000)
+
+/* AHB peripherals                                                            */
+#define LPC_EMAC_BASE         (LPC_AHB_BASE  + 0x00000)
+#define LPC_GPDMA_BASE        (LPC_AHB_BASE  + 0x04000)
+#define LPC_GPDMACH0_BASE     (LPC_AHB_BASE  + 0x04100)
+#define LPC_GPDMACH1_BASE     (LPC_AHB_BASE  + 0x04120)
+#define LPC_GPDMACH2_BASE     (LPC_AHB_BASE  + 0x04140)
+#define LPC_GPDMACH3_BASE     (LPC_AHB_BASE  + 0x04160)
+#define LPC_GPDMACH4_BASE     (LPC_AHB_BASE  + 0x04180)
+#define LPC_GPDMACH5_BASE     (LPC_AHB_BASE  + 0x041A0)
+#define LPC_GPDMACH6_BASE     (LPC_AHB_BASE  + 0x041C0)
+#define LPC_GPDMACH7_BASE     (LPC_AHB_BASE  + 0x041E0)
+#define LPC_USB_BASE          (LPC_AHB_BASE  + 0x0C000)
+
+/* GPIOs                                                                      */
+#define LPC_GPIO0_BASE        (LPC_GPIO_BASE + 0x00000)
+#define LPC_GPIO1_BASE        (LPC_GPIO_BASE + 0x00020)
+#define LPC_GPIO2_BASE        (LPC_GPIO_BASE + 0x00040)
+#define LPC_GPIO3_BASE        (LPC_GPIO_BASE + 0x00060)
+#define LPC_GPIO4_BASE        (LPC_GPIO_BASE + 0x00080)
+
+
+/******************************************************************************/
+/*                         Peripheral declaration                             */
+/******************************************************************************/
+#define LPC_SC                ((LPC_SC_TypeDef        *) LPC_SC_BASE       )
+#define LPC_GPIO0             ((LPC_GPIO_TypeDef      *) LPC_GPIO0_BASE    )
+#define LPC_GPIO1             ((LPC_GPIO_TypeDef      *) LPC_GPIO1_BASE    )
+#define LPC_GPIO2             ((LPC_GPIO_TypeDef      *) LPC_GPIO2_BASE    )
+#define LPC_GPIO3             ((LPC_GPIO_TypeDef      *) LPC_GPIO3_BASE    )
+#define LPC_GPIO4             ((LPC_GPIO_TypeDef      *) LPC_GPIO4_BASE    )
+#define LPC_WDT               ((LPC_WDT_TypeDef       *) LPC_WDT_BASE      )
+#define LPC_TIM0              ((LPC_TIM_TypeDef       *) LPC_TIM0_BASE     )
+#define LPC_TIM1              ((LPC_TIM_TypeDef       *) LPC_TIM1_BASE     )
+#define LPC_TIM2              ((LPC_TIM_TypeDef       *) LPC_TIM2_BASE     )
+#define LPC_TIM3              ((LPC_TIM_TypeDef       *) LPC_TIM3_BASE     )
+#define LPC_RIT               ((LPC_RIT_TypeDef       *) LPC_RIT_BASE      )
+#define LPC_UART0             ((LPC_UART0_TypeDef     *) LPC_UART0_BASE    )
+#define LPC_UART1             ((LPC_UART1_TypeDef     *) LPC_UART1_BASE    )
+#define LPC_UART2             ((LPC_UART_TypeDef      *) LPC_UART2_BASE    )
+#define LPC_UART3             ((LPC_UART_TypeDef      *) LPC_UART3_BASE    )
+#define LPC_PWM1              ((LPC_PWM_TypeDef       *) LPC_PWM1_BASE     )
+#define LPC_I2C0              ((LPC_I2C_TypeDef       *) LPC_I2C0_BASE     )
+#define LPC_I2C1              ((LPC_I2C_TypeDef       *) LPC_I2C1_BASE     )
+#define LPC_I2C2              ((LPC_I2C_TypeDef       *) LPC_I2C2_BASE     )
+#define LPC_I2S               ((LPC_I2S_TypeDef       *) LPC_I2S_BASE      )
+#define LPC_SPI               ((LPC_SPI_TypeDef       *) LPC_SPI_BASE      )
+#define LPC_RTC               ((LPC_RTC_TypeDef       *) LPC_RTC_BASE      )
+#define LPC_GPIOINT           ((LPC_GPIOINT_TypeDef   *) LPC_GPIOINT_BASE  )
+#define LPC_PINCON            ((LPC_PINCON_TypeDef    *) LPC_PINCON_BASE   )
+#define LPC_SSP0              ((LPC_SSP_TypeDef       *) LPC_SSP0_BASE     )
+#define LPC_SSP1              ((LPC_SSP_TypeDef       *) LPC_SSP1_BASE     )
+#define LPC_ADC               ((LPC_ADC_TypeDef       *) LPC_ADC_BASE      )
+#define LPC_DAC               ((LPC_DAC_TypeDef       *) LPC_DAC_BASE      )
+#define LPC_CANAF_RAM         ((LPC_CANAF_RAM_TypeDef *) LPC_CANAF_RAM_BASE)
+#define LPC_CANAF             ((LPC_CANAF_TypeDef     *) LPC_CANAF_BASE    )
+#define LPC_CANCR             ((LPC_CANCR_TypeDef     *) LPC_CANCR_BASE    )
+#define LPC_CAN1              ((LPC_CAN_TypeDef       *) LPC_CAN1_BASE     )
+#define LPC_CAN2              ((LPC_CAN_TypeDef       *) LPC_CAN2_BASE     )
+#define LPC_MCPWM             ((LPC_MCPWM_TypeDef     *) LPC_MCPWM_BASE    )
+#define LPC_QEI               ((LPC_QEI_TypeDef       *) LPC_QEI_BASE      )
+#define LPC_EMAC              ((LPC_EMAC_TypeDef      *) LPC_EMAC_BASE     )
+#define LPC_GPDMA             ((LPC_GPDMA_TypeDef     *) LPC_GPDMA_BASE    )
+#define LPC_GPDMACH0          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH0_BASE )
+#define LPC_GPDMACH1          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH1_BASE )
+#define LPC_GPDMACH2          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH2_BASE )
+#define LPC_GPDMACH3          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH3_BASE )
+#define LPC_GPDMACH4          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH4_BASE )
+#define LPC_GPDMACH5          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH5_BASE )
+#define LPC_GPDMACH6          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH6_BASE )
+#define LPC_GPDMACH7          ((LPC_GPDMACH_TypeDef   *) LPC_GPDMACH7_BASE )
+#define LPC_USB               ((LPC_USB_TypeDef       *) LPC_USB_BASE      )
+
+#endif  // __LPC17xx_H__

--- a/lib/lpc176x/device/system_LPC17xx.c
+++ b/lib/lpc176x/device/system_LPC17xx.c
@@ -1,0 +1,581 @@
+/**************************************************************************//**
+ * @file     system_LPC17xx.c
+ * @brief    CMSIS Cortex-M3 Device System Source File for
+ *           NXP LPC17xx Device Series
+ * @version  V1.11
+ * @date     21. June 2011
+ *
+ * @note
+ * Copyright (C) 2009-2011 ARM Limited. All rights reserved.
+ *
+ * @par
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M
+ * processor based microcontrollers.  This file can be freely distributed
+ * within development tools that are supporting such ARM based processors.
+ *
+ * @par
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+
+#include <stdint.h>
+#include "LPC17xx.h"
+
+
+/** @addtogroup LPC17xx_System
+ * @{
+ */
+
+/*
+//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+*/
+
+/*--------------------- Clock Configuration ----------------------------------
+//
+// <e> Clock Configuration
+//   <h> System Controls and Status Register (SCS)
+//     <o1.4>    OSCRANGE: Main Oscillator Range Select
+//                     <0=>  1 MHz to 20 MHz
+//                     <1=> 15 MHz to 25 MHz
+//     <e1.5>       OSCEN: Main Oscillator Enable
+//     </e>
+//   </h>
+//
+//   <h> Clock Source Select Register (CLKSRCSEL)
+//     <o2.0..1>   CLKSRC: PLL Clock Source Selection
+//                     <0=> Internal RC oscillator
+//                     <1=> Main oscillator
+//                     <2=> RTC oscillator
+//   </h>
+//
+//   <e3> PLL0 Configuration (Main PLL)
+//     <h> PLL0 Configuration Register (PLL0CFG)
+//                     <i> F_cco0 = (2 * M * F_in) / N
+//                     <i> F_in must be in the range of 32 kHz to 50 MHz
+//                     <i> F_cco0 must be in the range of 275 MHz to 550 MHz
+//       <o4.0..14>  MSEL: PLL Multiplier Selection
+//                     <6-32768><#-1>
+//                     <i> M Value
+//       <o4.16..23> NSEL: PLL Divider Selection
+//                     <1-256><#-1>
+//                     <i> N Value
+//     </h>
+//   </e>
+//
+//   <e5> PLL1 Configuration (USB PLL)
+//     <h> PLL1 Configuration Register (PLL1CFG)
+//                     <i> F_usb = M * F_osc or F_usb = F_cco1 / (2 * P)
+//                     <i> F_cco1 = F_osc * M * 2 * P
+//                     <i> F_cco1 must be in the range of 156 MHz to 320 MHz
+//       <o6.0..4>   MSEL: PLL Multiplier Selection
+//                     <1-32><#-1>
+//                     <i> M Value (for USB maximum value is 4)
+//       <o6.5..6>   PSEL: PLL Divider Selection
+//                     <0=> 1
+//                     <1=> 2
+//                     <2=> 4
+//                     <3=> 8
+//                     <i> P Value
+//     </h>
+//   </e>
+//
+//   <h> CPU Clock Configuration Register (CCLKCFG)
+//     <o7.0..7>  CCLKSEL: Divide Value for CPU Clock from PLL0
+//                     <1-256><#-1>
+//   </h>
+//
+//   <h> USB Clock Configuration Register (USBCLKCFG)
+//     <o8.0..3>   USBSEL: Divide Value for USB Clock from PLL0
+//                     <0-15>
+//                     <i> Divide is USBSEL + 1
+//   </h>
+//
+//   <h> Peripheral Clock Selection Register 0 (PCLKSEL0)
+//     <o9.0..1>    PCLK_WDT: Peripheral Clock Selection for WDT
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.2..3>    PCLK_TIMER0: Peripheral Clock Selection for TIMER0
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.4..5>    PCLK_TIMER1: Peripheral Clock Selection for TIMER1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.6..7>    PCLK_UART0: Peripheral Clock Selection for UART0
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.8..9>    PCLK_UART1: Peripheral Clock Selection for UART1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.12..13>  PCLK_PWM1: Peripheral Clock Selection for PWM1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.14..15>  PCLK_I2C0: Peripheral Clock Selection for I2C0
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.16..17>  PCLK_SPI: Peripheral Clock Selection for SPI
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.20..21>  PCLK_SSP1: Peripheral Clock Selection for SSP1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.22..23>  PCLK_DAC: Peripheral Clock Selection for DAC
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.24..25>  PCLK_ADC: Peripheral Clock Selection for ADC
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o9.26..27>  PCLK_CAN1: Peripheral Clock Selection for CAN1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 6
+//     <o9.28..29>  PCLK_CAN2: Peripheral Clock Selection for CAN2
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 6
+//     <o9.30..31>  PCLK_ACF: Peripheral Clock Selection for ACF
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 6
+//   </h>
+//
+//   <h> Peripheral Clock Selection Register 1 (PCLKSEL1)
+//     <o10.0..1>   PCLK_QEI: Peripheral Clock Selection for the Quadrature Encoder Interface
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.2..3>   PCLK_GPIO: Peripheral Clock Selection for GPIOs
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.4..5>   PCLK_PCB: Peripheral Clock Selection for the Pin Connect Block
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.6..7>   PCLK_I2C1: Peripheral Clock Selection for I2C1
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.10..11> PCLK_SSP0: Peripheral Clock Selection for SSP0
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.12..13> PCLK_TIMER2: Peripheral Clock Selection for TIMER2
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.14..15> PCLK_TIMER3: Peripheral Clock Selection for TIMER3
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.16..17> PCLK_UART2: Peripheral Clock Selection for UART2
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.18..19> PCLK_UART3: Peripheral Clock Selection for UART3
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.20..21> PCLK_I2C2: Peripheral Clock Selection for I2C2
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.22..23> PCLK_I2S: Peripheral Clock Selection for I2S
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.26..27> PCLK_RIT: Peripheral Clock Selection for the Repetitive Interrupt Timer
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.28..29> PCLK_SYSCON: Peripheral Clock Selection for the System Control Block
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//     <o10.30..31> PCLK_MC: Peripheral Clock Selection for the Motor Control PWM
+//                     <0=> Pclk = Cclk / 4
+//                     <1=> Pclk = Cclk
+//                     <2=> Pclk = Cclk / 2
+//                     <3=> Pclk = Hclk / 8
+//   </h>
+//
+//   <h> Power Control for Peripherals Register (PCONP)
+//     <o11.1>      PCTIM0: Timer/Counter 0 power/clock enable
+//     <o11.2>      PCTIM1: Timer/Counter 1 power/clock enable
+//     <o11.3>      PCUART0: UART 0 power/clock enable
+//     <o11.4>      PCUART1: UART 1 power/clock enable
+//     <o11.6>      PCPWM1: PWM 1 power/clock enable
+//     <o11.7>      PCI2C0: I2C interface 0 power/clock enable
+//     <o11.8>      PCSPI: SPI interface power/clock enable
+//     <o11.9>      PCRTC: RTC power/clock enable
+//     <o11.10>     PCSSP1: SSP interface 1 power/clock enable
+//     <o11.12>     PCAD: A/D converter power/clock enable
+//     <o11.13>     PCCAN1: CAN controller 1 power/clock enable
+//     <o11.14>     PCCAN2: CAN controller 2 power/clock enable
+//     <o11.15>     PCGPIO: GPIOs power/clock enable
+//     <o11.16>     PCRIT: Repetitive interrupt timer power/clock enable
+//     <o11.17>     PCMC: Motor control PWM power/clock enable
+//     <o11.18>     PCQEI: Quadrature encoder interface power/clock enable
+//     <o11.19>     PCI2C1: I2C interface 1 power/clock enable
+//     <o11.21>     PCSSP0: SSP interface 0 power/clock enable
+//     <o11.22>     PCTIM2: Timer 2 power/clock enable
+//     <o11.23>     PCTIM3: Timer 3 power/clock enable
+//     <o11.24>     PCUART2: UART 2 power/clock enable
+//     <o11.25>     PCUART3: UART 3 power/clock enable
+//     <o11.26>     PCI2C2: I2C interface 2 power/clock enable
+//     <o11.27>     PCI2S: I2S interface power/clock enable
+//     <o11.29>     PCGPDMA: GP DMA function power/clock enable
+//     <o11.30>     PCENET: Ethernet block power/clock enable
+//     <o11.31>     PCUSB: USB interface power/clock enable
+//   </h>
+//
+//   <h> Clock Output Configuration Register (CLKOUTCFG)
+//     <o12.0..3>   CLKOUTSEL: Selects clock source for CLKOUT
+//                     <0=> CPU clock
+//                     <1=> Main oscillator
+//                     <2=> Internal RC oscillator
+//                     <3=> USB clock
+//                     <4=> RTC oscillator
+//     <o12.4..7>   CLKOUTDIV: Selects clock divider for CLKOUT
+//                     <1-16><#-1>
+//     <o12.8>      CLKOUT_EN: CLKOUT enable control
+//   </h>
+//
+// </e>
+*/
+
+
+
+/** @addtogroup LPC17xx_System_Defines  LPC17xx System Defines
+  @{
+ */
+
+#define CLOCK_SETUP           1
+#define SCS_Val               0x00000020
+#define CLKSRCSEL_Val         0x00000001
+#define PLL0_SETUP            1
+
+#include "autoconf.h" // CONFIG_MACH_LPC1769
+#if CONFIG_MACH_LPC1769
+# define PLL0CFG_Val           0x0000000E
+#else
+# define PLL0CFG_Val           0x00010018
+#endif
+#define PLL1_SETUP            1
+#define PLL1CFG_Val           0x00000023
+#define CCLKCFG_Val           0x00000002
+#define USBCLKCFG_Val         0x00000000
+
+#define PCLKSEL0_Val          0x55515155
+#define PCLKSEL1_Val          0x54555455
+#define PCONP_Val             0x042887DE
+#define CLKOUTCFG_Val         0x00000000
+
+
+/*--------------------- Flash Accelerator Configuration ----------------------
+//
+// <e> Flash Accelerator Configuration
+//   <o1.12..15> FLASHTIM: Flash Access Time
+//               <0=> 1 CPU clock (for CPU clock up to 20 MHz)
+//               <1=> 2 CPU clocks (for CPU clock up to 40 MHz)
+//               <2=> 3 CPU clocks (for CPU clock up to 60 MHz)
+//               <3=> 4 CPU clocks (for CPU clock up to 80 MHz)
+//               <4=> 5 CPU clocks (for CPU clock up to 100 MHz)
+//               <5=> 6 CPU clocks (for any CPU clock)
+// </e>
+*/
+#define FLASH_SETUP           1
+#define FLASHCFG_Val          0x0000303A
+
+/*
+//-------- <<< end of configuration section >>> ------------------------------
+*/
+
+/*----------------------------------------------------------------------------
+  Check the register settings
+ *----------------------------------------------------------------------------*/
+#define CHECK_RANGE(val, min, max)                ((val < min) || (val > max))
+#define CHECK_RSVD(val, mask)                     (val & mask)
+
+/* Clock Configuration -------------------------------------------------------*/
+#if (CHECK_RSVD((SCS_Val),       ~0x00000030))
+   #error "SCS: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RANGE((CLKSRCSEL_Val), 0, 2))
+   #error "CLKSRCSEL: Value out of range!"
+#endif
+
+#if (CHECK_RSVD((PLL0CFG_Val),   ~0x00FF7FFF))
+   #error "PLL0CFG: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PLL1CFG_Val),   ~0x0000007F))
+   #error "PLL1CFG: Invalid values of reserved bits!"
+#endif
+
+#if (PLL0_SETUP)            /* if PLL0 is used */
+  #if (CCLKCFG_Val < 2)     /* CCLKSEL must be greater then 1 */
+    #error "CCLKCFG: CCLKSEL must be greater then 1 if PLL0 is used!"
+  #endif
+#endif
+
+#if (CHECK_RANGE((CCLKCFG_Val), 2, 255))
+   #error "CCLKCFG: Value out of range!"
+#endif
+
+#if (CHECK_RSVD((USBCLKCFG_Val), ~0x0000000F))
+   #error "USBCLKCFG: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCLKSEL0_Val),   0x000C0C00))
+   #error "PCLKSEL0: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCLKSEL1_Val),   0x03000300))
+   #error "PCLKSEL1: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((PCONP_Val),      0x10100821))
+   #error "PCONP: Invalid values of reserved bits!"
+#endif
+
+#if (CHECK_RSVD((CLKOUTCFG_Val), ~0x000001FF))
+   #error "CLKOUTCFG: Invalid values of reserved bits!"
+#endif
+
+/* Flash Accelerator Configuration -------------------------------------------*/
+#if (CHECK_RSVD((FLASHCFG_Val), ~0x0000F07F))
+   #error "FLASHCFG: Invalid values of reserved bits!"
+#endif
+
+
+/*----------------------------------------------------------------------------
+  DEFINES
+ *----------------------------------------------------------------------------*/
+
+/*----------------------------------------------------------------------------
+  Define clocks
+ *----------------------------------------------------------------------------*/
+#define XTAL        (12000000UL)        /* Oscillator frequency               */
+#define OSC_CLK     (      XTAL)        /* Main oscillator frequency          */
+#define RTC_CLK     (   32000UL)        /* RTC oscillator frequency           */
+#define IRC_OSC     ( 4000000UL)        /* Internal RC oscillator frequency   */
+
+
+/* F_cco0 = (2 * M * F_in) / N  */
+#define __M               (((PLL0CFG_Val      ) & 0x7FFF) + 1)
+#define __N               (((PLL0CFG_Val >> 16) & 0x00FF) + 1)
+#define __FCCO(__F_IN)    ((2ULL * __M * __F_IN) / __N)
+#define __CCLK_DIV        (((CCLKCFG_Val      ) & 0x00FF) + 1)
+
+/* Determine core clock frequency according to settings */
+ #if (PLL0_SETUP)
+    #if   ((CLKSRCSEL_Val & 0x03) == 1)
+        #define __CORE_CLK (__FCCO(OSC_CLK) / __CCLK_DIV)
+    #elif ((CLKSRCSEL_Val & 0x03) == 2)
+        #define __CORE_CLK (__FCCO(RTC_CLK) / __CCLK_DIV)
+    #else
+        #define __CORE_CLK (__FCCO(IRC_OSC) / __CCLK_DIV)
+    #endif
+ #else
+    #if   ((CLKSRCSEL_Val & 0x03) == 1)
+        #define __CORE_CLK (OSC_CLK         / __CCLK_DIV)
+    #elif ((CLKSRCSEL_Val & 0x03) == 2)
+        #define __CORE_CLK (RTC_CLK         / __CCLK_DIV)
+    #else
+        #define __CORE_CLK (IRC_OSC         / __CCLK_DIV)
+    #endif
+ #endif
+
+/**
+ * @}
+ */
+
+
+/** @addtogroup LPC17xx_System_Public_Variables  LPC17xx System Public Variables
+  @{
+ */
+/*----------------------------------------------------------------------------
+  Clock Variable definitions
+ *----------------------------------------------------------------------------*/
+uint32_t SystemCoreClock = __CORE_CLK;/*!< System Clock Frequency (Core Clock)*/
+
+/**
+ * @}
+ */
+
+
+/** @addtogroup LPC17xx_System_Public_Functions  LPC17xx System Public Functions
+  @{
+ */
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock
+ *         retrieved from cpu registers.
+ */void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
+{
+  /* Determine clock frequency according to clock register values             */
+  if (((LPC_SC->PLL0STAT >> 24) & 3) == 3) { /* If PLL0 enabled and connected */
+    switch (LPC_SC->CLKSRCSEL & 0x03) {
+      case 0:                                /* Int. RC oscillator => PLL0    */
+      case 3:                                /* Reserved, default to Int. RC  */
+        SystemCoreClock = (IRC_OSC *
+                          ((2ULL * ((LPC_SC->PLL0STAT & 0x7FFF) + 1)))  /
+                          (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1)       /
+                          ((LPC_SC->CCLKCFG & 0xFF)+ 1));
+        break;
+      case 1:                                /* Main oscillator => PLL0       */
+        SystemCoreClock = (OSC_CLK *
+                          ((2ULL * ((LPC_SC->PLL0STAT & 0x7FFF) + 1)))  /
+                          (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1)       /
+                          ((LPC_SC->CCLKCFG & 0xFF)+ 1));
+        break;
+      case 2:                                /* RTC oscillator => PLL0        */
+        SystemCoreClock = (RTC_CLK *
+                          ((2ULL * ((LPC_SC->PLL0STAT & 0x7FFF) + 1)))  /
+                          (((LPC_SC->PLL0STAT >> 16) & 0xFF) + 1)       /
+                          ((LPC_SC->CCLKCFG & 0xFF)+ 1));
+        break;
+    }
+  } else {
+    switch (LPC_SC->CLKSRCSEL & 0x03) {
+      case 0:                                /* Int. RC oscillator => PLL0    */
+      case 3:                                /* Reserved, default to Int. RC  */
+        SystemCoreClock = IRC_OSC / ((LPC_SC->CCLKCFG & 0xFF)+ 1);
+        break;
+      case 1:                                /* Main oscillator => PLL0       */
+        SystemCoreClock = OSC_CLK / ((LPC_SC->CCLKCFG & 0xFF)+ 1);
+        break;
+      case 2:                                /* RTC oscillator => PLL0        */
+        SystemCoreClock = RTC_CLK / ((LPC_SC->CCLKCFG & 0xFF)+ 1);
+        break;
+    }
+  }
+
+}
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System.
+ */
+void SystemInit (void)
+{
+#if (CLOCK_SETUP)                       /* Clock Setup                        */
+  LPC_SC->SCS       = SCS_Val;
+  if (LPC_SC->SCS & (1 << 5)) {             /* If Main Oscillator is enabled  */
+    while ((LPC_SC->SCS & (1<<6)) == 0);/* Wait for Oscillator to be ready    */
+  }
+
+  LPC_SC->CCLKCFG   = CCLKCFG_Val;      /* Setup Clock Divider                */
+  /* Periphral clock must be selected before PLL0 enabling and connecting
+   * - according errata.lpc1768-16.March.2010 -
+   */
+  LPC_SC->PCLKSEL0  = PCLKSEL0_Val;     /* Peripheral Clock Selection         */
+  LPC_SC->PCLKSEL1  = PCLKSEL1_Val;
+
+#if (PLL0_SETUP)
+  LPC_SC->CLKSRCSEL = CLKSRCSEL_Val;    /* Select Clock Source for PLL0       */
+
+  LPC_SC->PLL0CFG   = PLL0CFG_Val;      /* configure PLL0                     */
+  LPC_SC->PLL0FEED  = 0xAA;
+  LPC_SC->PLL0FEED  = 0x55;
+
+  LPC_SC->PLL0CON   = 0x01;             /* PLL0 Enable                        */
+  LPC_SC->PLL0FEED  = 0xAA;
+  LPC_SC->PLL0FEED  = 0x55;
+  while (!(LPC_SC->PLL0STAT & (1<<26)));/* Wait for PLOCK0                    */
+
+  LPC_SC->PLL0CON   = 0x03;             /* PLL0 Enable & Connect              */
+  LPC_SC->PLL0FEED  = 0xAA;
+  LPC_SC->PLL0FEED  = 0x55;
+  while (!(LPC_SC->PLL0STAT & ((1<<25) | (1<<24))));/* Wait for PLLC0_STAT & PLLE0_STAT */
+#endif
+
+#if (PLL1_SETUP)
+  LPC_SC->PLL1CFG   = PLL1CFG_Val;
+  LPC_SC->PLL1FEED  = 0xAA;
+  LPC_SC->PLL1FEED  = 0x55;
+
+  LPC_SC->PLL1CON   = 0x01;             /* PLL1 Enable                        */
+  LPC_SC->PLL1FEED  = 0xAA;
+  LPC_SC->PLL1FEED  = 0x55;
+  while (!(LPC_SC->PLL1STAT & (1<<10)));/* Wait for PLOCK1                    */
+
+  LPC_SC->PLL1CON   = 0x03;             /* PLL1 Enable & Connect              */
+  LPC_SC->PLL1FEED  = 0xAA;
+  LPC_SC->PLL1FEED  = 0x55;
+  while (!(LPC_SC->PLL1STAT & ((1<< 9) | (1<< 8))));/* Wait for PLLC1_STAT & PLLE1_STAT */
+#else
+  LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider            */
+#endif
+
+  LPC_SC->PCONP     = PCONP_Val;        /* Power Control for Peripherals      */
+
+  LPC_SC->CLKOUTCFG = CLKOUTCFG_Val;    /* Clock Output Configuration         */
+#endif
+
+#if (FLASH_SETUP == 1)                  /* Flash Accelerator Setup            */
+  LPC_SC->FLASHCFG  = (LPC_SC->FLASHCFG & ~0x0000F000) | FLASHCFG_Val;
+#endif
+}
+
+/**
+ * @}
+ */
+
+/**
+ * @}
+ */

--- a/lib/lpc176x/device/system_LPC17xx.c
+++ b/lib/lpc176x/device/system_LPC17xx.c
@@ -327,7 +327,7 @@
 // </e>
 */
 #define FLASH_SETUP           1
-#define FLASHCFG_Val          0x0000303A
+#define FLASHCFG_Val          0x0000403A
 
 /*
 //-------- <<< end of configuration section >>> ------------------------------

--- a/lib/lpc176x/device/system_LPC17xx.h
+++ b/lib/lpc176x/device/system_LPC17xx.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ * @file:    system_LPC17xx.h
+ * @purpose: CMSIS Cortex-M3 Device Peripheral Access Layer Header File
+ *           for the NXP LPC17xx Device Series 
+ * @version: V1.02
+ * @date:    27. July 2009
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (C) 2009 ARM Limited. All rights reserved.
+ *
+ * ARM Limited (ARM) is supplying this software for use with Cortex-M3 
+ * processor based microcontrollers.  This file can be freely distributed 
+ * within development tools that are supporting such ARM based processors. 
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS".  NO WARRANTIES, WHETHER EXPRESS, IMPLIED
+ * OR STATUTORY, INCLUDING, BUT NOT LIMITED TO, IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE APPLY TO THIS SOFTWARE.
+ * ARM SHALL NOT, IN ANY CIRCUMSTANCES, BE LIABLE FOR SPECIAL, INCIDENTAL, OR
+ * CONSEQUENTIAL DAMAGES, FOR ANY REASON WHATSOEVER.
+ *
+ ******************************************************************************/
+
+
+#ifndef __SYSTEM_LPC17xx_H
+#define __SYSTEM_LPC17xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
+
+
+/**
+ * Initialize the system
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Setup the microcontroller system.
+ *         Initialize the System and update the SystemCoreClock variable.
+ */
+extern void SystemInit (void);
+
+/**
+ * Update SystemCoreClock variable
+ *
+ * @param  none
+ * @return none
+ *
+ * @brief  Updates the SystemCoreClock with current core Clock 
+ *         retrieved from cpu registers.
+ */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __SYSTEM_LPC17xx_H */

--- a/lib/lpc176x/lpc176x.patch
+++ b/lib/lpc176x/lpc176x.patch
@@ -1,0 +1,35 @@
+--- device/system_LPC17xx.c	2018-05-02 12:23:57.292132454 -0400
++++ device/system_LPC17xx.c	2021-05-04 10:08:17.637502030 -0400
+@@ -297,22 +297,19 @@
+ #define CLKSRCSEL_Val         0x00000001
+ #define PLL0_SETUP            1
+ 
+-#ifdef MCB1700
+-#    define PLL0CFG_Val           0x00050063
+-#    define PLL1_SETUP            1
+-#    define PLL1CFG_Val           0x00000023
+-#    define CCLKCFG_Val           0x00000003
+-#    define USBCLKCFG_Val         0x00000000
++#include "autoconf.h" // CONFIG_MACH_LPC1769
++#if CONFIG_MACH_LPC1769
++# define PLL0CFG_Val           0x0000000E
+ #else
+-#    define PLL0CFG_Val           0x0000000B
+-#    define PLL1_SETUP            0
+-#    define PLL1CFG_Val           0x00000000
+-#    define CCLKCFG_Val           0x00000002
+-#    define USBCLKCFG_Val         0x00000005
++# define PLL0CFG_Val           0x00010018
+ #endif
++#define PLL1_SETUP            1
++#define PLL1CFG_Val           0x00000023
++#define CCLKCFG_Val           0x00000002
++#define USBCLKCFG_Val         0x00000000
+ 
+-#define PCLKSEL0_Val          0x00000000
+-#define PCLKSEL1_Val          0x00000000
++#define PCLKSEL0_Val          0x55515155
++#define PCLKSEL1_Val          0x54555455
+ #define PCONP_Val             0x042887DE
+ #define CLKOUTCFG_Val         0x00000000
+ 

--- a/src/Kconfig
+++ b/src/Kconfig
@@ -6,11 +6,16 @@ config LOW_LEVEL_OPTIONS
     bool
     default y
 
-config MACH_STM32
-    bool
-    default y
+choice
+    prompt "Micro-controller Architecture"
+    config MACH_STM32
+        bool "STMicroelectronics STM32"
+    config MACH_LPC176X
+        bool "LPC176x (Smoothieboard)"
+endchoice
 
 source "src/stm32/Kconfig"
+source "src/lpc176x/Kconfig"
 
 # Generic configuration options for serial ports
 config SERIAL_BAUD

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -1,0 +1,89 @@
+# Kconfig settings for LPC176x processors
+
+if MACH_LPC176X
+
+config LPC_SELECT
+    bool
+    default y
+    select HAVE_GPIO
+    select HAVE_GPIO_ADC
+    select HAVE_GPIO_I2C
+    select HAVE_GPIO_SPI
+    select HAVE_GPIO_BITBANGING
+    select HAVE_STRICT_TIMING
+    select HAVE_CHIPID
+    select HAVE_GPIO_HARD_PWM
+    select HAVE_STEPPER_BOTH_EDGE
+
+config BOARD_DIRECTORY
+    string
+    default "lpc176x"
+
+choice
+    prompt "Processor model"
+    config MACH_LPC1768
+        bool "lpc1768 (100 MHz)"
+    config MACH_LPC1769
+        bool "lpc1769 (120 MHz)"
+endchoice
+
+config MCU
+    string
+    default "lpc1768" if MACH_LPC1768
+    default "lpc1769" if MACH_LPC1769
+
+config CLOCK_FREQ
+    int
+    default 100000000 if MACH_LPC1768
+    default 120000000 if MACH_LPC1769
+
+config FLASH_SIZE
+    hex
+    default 0x80000
+
+config RAM_START
+    hex
+    default 0x10000000
+
+config RAM_SIZE
+    hex
+    default 0x7fe0 # (0x8000 - 32) - top 32 bytes used by IAP functions
+
+config STACK_SIZE
+    int
+    default 512
+
+config FLASH_START
+    hex
+    default 0x0000
+
+config USBSERIAL
+    bool
+config SERIAL
+    bool
+choice
+    prompt "Communication interface"
+    config LPC_USB
+        bool "USB"
+        select USBSERIAL
+    config LPC_SERIAL_UART0_P03_P02
+        bool "Serial (on UART0 P0.3/P0.2)"
+        select SERIAL
+    config LPC_SERIAL_UART3_P429_P428
+        bool "Serial (on UART3 P4.29/P4.28)" if LOW_LEVEL_OPTIONS
+        select SERIAL
+endchoice
+
+######################################################################
+# Flash settings
+######################################################################
+
+config APPLICATION_START
+    hex
+    default 0x4000
+
+config BLOCK_SIZE
+    int
+    default 64
+
+endif

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -47,7 +47,7 @@ config RAM_START
 
 config RAM_SIZE
     hex
-    default 0x7f20 # (0x8000 - 224) places stack end at a location not used by boot rom
+    default 0x7ee0 # (0x8000 - 256 - 32) 32 bytes for ISP commands, 256 bytes for ISP stack
 
 config STACK_SIZE
     int

--- a/src/lpc176x/Kconfig
+++ b/src/lpc176x/Kconfig
@@ -47,7 +47,7 @@ config RAM_START
 
 config RAM_SIZE
     hex
-    default 0x7fe0 # (0x8000 - 32) - top 32 bytes used by IAP functions
+    default 0x7f20 # (0x8000 - 224) places stack end at a location not used by boot rom
 
 config STACK_SIZE
     int

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -1,0 +1,31 @@
+# lpc176x build rules
+
+# Setup the toolchain
+CROSS_PREFIX=arm-none-eabi-
+
+dirs-y += src/lpc176x src/generic lib/lpc176x/device
+
+CFLAGS += -mthumb -mcpu=cortex-m3 -Ilib/lpc176x/device -Ilib/cmsis-core
+
+CFLAGS_canboot.elf += --specs=nano.specs --specs=nosys.specs
+CFLAGS_canboot.elf += -T $(OUT)src/generic/armcm_link.ld
+$(OUT)canboot.elf: $(OUT)src/generic/armcm_link.ld
+
+# Add source files
+src-y += lpc176x/main.c lpc176x/gpio.c
+src-y += generic/armcm_boot.c generic/armcm_irq.c
+src-y += generic/armcm_timer.c generic/crc16_ccitt.c
+src-y += ../lib/lpc176x/device/system_LPC17xx.c
+
+src-$(CONFIG_USBSERIAL) += lpc176x/usbserial.c lpc176x/chipid.c
+src-$(CONFIG_USBSERIAL) += generic/usb_cdc.c
+src-$(CONFIG_SERIAL) += lpc176x/serial.c generic/serial_irq.c
+
+
+# Build the additional bin output file
+target-y += $(OUT)canboot.bin
+
+$(OUT)canboot.bin: $(OUT)canboot.elf
+	@echo "  Creating hex file $@"
+	$(Q)$(OBJCOPY) -O binary $< $(OUT)canboot.work
+	$(Q)$(PYTHON) ./scripts/buildbinary.py -b $(CONFIG_FLASH_START) -s $(CONFIG_APPLICATION_START) $(OUT)canboot.work $@

--- a/src/lpc176x/Makefile
+++ b/src/lpc176x/Makefile
@@ -12,7 +12,7 @@ CFLAGS_canboot.elf += -T $(OUT)src/generic/armcm_link.ld
 $(OUT)canboot.elf: $(OUT)src/generic/armcm_link.ld
 
 # Add source files
-src-y += lpc176x/main.c lpc176x/gpio.c
+src-y += lpc176x/main.c lpc176x/gpio.c lpc176x/flash.c
 src-y += generic/armcm_boot.c generic/armcm_irq.c
 src-y += generic/armcm_timer.c generic/crc16_ccitt.c
 src-y += ../lib/lpc176x/device/system_LPC17xx.c

--- a/src/lpc176x/chipid.c
+++ b/src/lpc176x/chipid.c
@@ -1,0 +1,46 @@
+// Support for extracting the hardware chip id on lpc176x
+//
+// Copyright (C) 2019  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_USB_SERIAL_NUMBER_CHIPID
+#include "generic/irq.h" // irq_disable
+#include "generic/usb_cdc.h" // usb_fill_serial
+#include "generic/usbstd.h" // usb_string_descriptor
+#include "sched.h" // DECL_INIT
+
+// IAP interface
+#define IAP_LOCATION        0x1fff1ff1
+#define IAP_CMD_READ_UID    58
+#define IAP_UID_LEN         16
+typedef void (*IAP)(uint32_t *, uint32_t *);
+
+static struct {
+    struct usb_string_descriptor desc;
+    uint16_t data[IAP_UID_LEN * 2];
+} cdc_chipid;
+
+struct usb_string_descriptor *
+usbserial_get_serialid(void)
+{
+   return &cdc_chipid.desc;
+}
+
+void
+chipid_init(void)
+{
+    if (!CONFIG_USB_SERIAL_NUMBER_CHIPID)
+        return;
+
+    uint32_t iap_cmd_uid[5] = {IAP_CMD_READ_UID, 0, 0, 0, 0};
+    uint32_t iap_resp[5];
+    IAP iap_entry = (IAP)IAP_LOCATION;
+    irq_disable();
+    iap_entry(iap_cmd_uid, iap_resp);
+    irq_enable();
+
+    usb_fill_serial(&cdc_chipid.desc, ARRAY_SIZE(cdc_chipid.data)
+                    , &iap_resp[1]);
+}
+DECL_INIT(chipid_init);

--- a/src/lpc176x/flash.c
+++ b/src/lpc176x/flash.c
@@ -1,0 +1,167 @@
+// Flash (IAP) functionality for LPC176x
+//
+// Copyright (C) 2021 Eric Callahan <arksine.code@gmail.com
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // memcpy
+#include "generic/irq.h" // irq_disable
+#include "autoconf.h" // CONFIG_BLOCK_SIZE
+#include "flash.h" // flash_write_page
+#include "compiler.h" // ALIGN_DOWN
+
+#define IAP_LOCATION        0x1fff1ff1
+#define IAP_CMD_PREPARE     50
+#define IAP_CMD_WRITE       51
+#define IAP_CMD_ERASE       52
+#define IAP_FREQ            (CONFIG_CLOCK_FREQ / 1000)
+#define IAP_BUF_MIN_SIZE        256
+typedef void (*IAP)(uint32_t *, uint32_t *);
+
+static uint8_t iap_buf[IAP_BUF_MIN_SIZE] __aligned(4);
+static uint32_t next_address = CONFIG_APPLICATION_START;
+static uint32_t page_write_count;
+
+// Return the flash sector index for the page at the given address
+static uint32_t
+flash_get_sector_index(uint32_t addr)
+{
+    if (addr < 0x00010000)
+        return addr / (4 * 1024);
+    else
+        return 16 + (addr - 0x00010000) / (32 * 1024);
+}
+
+
+// Return the flash page size at the given address
+static uint32_t
+flash_get_sector_size(uint32_t addr)
+{
+    if (addr < 0x00010000)
+        return 4 * 1024;
+    else
+        return 32 * 1024;
+}
+
+// Check if the data at the given address has been erased (all 0xff)
+static int
+check_erased(uint32_t addr, uint32_t count)
+{
+    uint32_t *p = (void*)addr, *e = (void*)addr + count / 4;
+    while (p < e)
+        if (*p++ != 0xffffffff)
+            return 0;
+    return 1;
+}
+
+static int
+call_iap(uint32_t* command)
+{
+    uint32_t iap_resp[5];
+    IAP iap_entry = (IAP)IAP_LOCATION;
+    irq_disable();
+    iap_entry(command, iap_resp);
+    irq_enable();
+    return iap_resp[0];
+}
+
+static int
+unlock_flash(uint32_t sector)
+{
+    uint32_t iap_cmd[5] = {IAP_CMD_PREPARE, sector, sector, IAP_FREQ, 0};
+    return call_iap(iap_cmd);
+}
+
+static int
+erase_sector(uint32_t sector)
+{
+    uint32_t iap_cmd[5] = {IAP_CMD_ERASE, sector, sector, IAP_FREQ, 0};
+    return call_iap(iap_cmd);
+}
+
+static int
+write_flash(uint32_t flash_address, uint32_t* data, uint32_t len)
+{
+    uint32_t iap_cmd[5] = {
+        IAP_CMD_WRITE, flash_address, (uint32_t)data, len, IAP_FREQ
+    };
+    return call_iap(iap_cmd);
+}
+
+static int
+write_buffer(uint32_t flash_address, uint32_t* data, uint32_t len)
+{
+    uint32_t flash_sector_size = flash_get_sector_size(flash_address);
+    uint32_t sector = flash_get_sector_index(flash_address);
+    uint32_t page_address = ALIGN_DOWN(flash_address, flash_sector_size);
+    if (page_address == flash_address) {
+        if (check_erased(flash_address, flash_sector_size)){
+            // sector already erased
+        }
+        else if (memcmp(data, (void*)flash_address, len) == 0 &&
+                 check_erased(flash_address + len, flash_sector_size - len))
+        {
+            // retransmit of this block
+            return 0;
+        }
+        else {
+            // sector needs to be erased
+            unlock_flash(sector);
+            if (erase_sector(sector) != 0)
+                return -3;
+        }
+        page_write_count += 1;
+    } else {
+        if (!check_erased(flash_address, len)) {
+            if (memcmp(data, (void*)flash_address, len) == 0)
+                return 0;
+            return -2;
+        }
+    }
+    unlock_flash(sector);
+    if (write_flash(flash_address, data, len) != 0)
+        return -4;
+    return 0;
+}
+
+int
+flash_write_block(uint32_t block_address, uint32_t *data)
+{
+    if (block_address & (CONFIG_BLOCK_SIZE - 1))
+        // Not a block aligned address
+        return -1;
+    if (CONFIG_BLOCK_SIZE < IAP_BUF_MIN_SIZE) {
+        if (block_address != next_address)
+            // out of order request
+            return -2;
+        uint32_t buf_idx = block_address & (IAP_BUF_MIN_SIZE - 1);
+        memcpy(&iap_buf[buf_idx], data, CONFIG_BLOCK_SIZE);
+        if (buf_idx == IAP_BUF_MIN_SIZE - CONFIG_BLOCK_SIZE) {
+            int ret = write_buffer(
+                block_address - buf_idx, (uint32_t*)iap_buf, IAP_BUF_MIN_SIZE
+            );
+            if (ret < 0)
+                return ret;
+        }
+        next_address += CONFIG_BLOCK_SIZE;
+    } else
+        return write_buffer(block_address, data, CONFIG_BLOCK_SIZE);
+    return 0;
+}
+
+int
+flash_complete(void)
+{
+    if (CONFIG_BLOCK_SIZE < IAP_BUF_MIN_SIZE) {
+        uint32_t buf_idx = next_address & (IAP_BUF_MIN_SIZE - 1);
+        if (buf_idx) {
+            memset(&iap_buf[buf_idx], 0xFF, (IAP_BUF_MIN_SIZE - buf_idx));
+            int ret = write_buffer(
+                next_address - buf_idx, (uint32_t*)iap_buf, IAP_BUF_MIN_SIZE
+            );
+            if (ret < 0)
+                return ret;
+        }
+    }
+    return page_write_count;
+}

--- a/src/lpc176x/flash.h
+++ b/src/lpc176x/flash.h
@@ -1,0 +1,9 @@
+#ifndef __LPC176X_FLASH_H
+#define __LPC176X_FLASH_H
+
+#include <stdint.h>
+
+int flash_write_block(uint32_t block_address, uint32_t *data);
+int flash_complete(void);
+
+#endif

--- a/src/lpc176x/gpio.c
+++ b/src/lpc176x/gpio.c
@@ -1,0 +1,144 @@
+// GPIO functions on lpc176x
+//
+// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // ffs
+#include "board/irq.h" // irq_save
+#include "command.h" // shutdown
+#include "gpio.h" // gpio_out_setup
+#include "internal.h" // gpio_peripheral
+#include "sched.h" // sched_shutdown
+
+
+/****************************************************************
+ * Pin mappings
+ ****************************************************************/
+
+DECL_ENUMERATION_RANGE("pin", "P0.0", GPIO(0, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P1.0", GPIO(1, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P2.0", GPIO(2, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P3.0", GPIO(3, 0), 32);
+DECL_ENUMERATION_RANGE("pin", "P4.0", GPIO(4, 0), 32);
+
+static LPC_GPIO_TypeDef * const digital_regs[] = {
+    LPC_GPIO0, LPC_GPIO1, LPC_GPIO2, LPC_GPIO3, LPC_GPIO4
+};
+
+// Set the mode and extended function of a pin
+void
+gpio_peripheral(uint32_t gpio, int func, int pull_up)
+{
+    uint32_t bank_pos = GPIO2PORT(gpio) * 2, pin_pos = (gpio % 32) * 2;
+    if (pin_pos >= 32) {
+        pin_pos -= 32;
+        bank_pos++;
+    }
+    uint32_t sel_bits = (func & 0x03) << pin_pos, mask = ~(0x03 << pin_pos);
+    uint32_t mode = (pull_up ? (pull_up > 0 ? 0x00 : 0x03) : 0x02) << pin_pos;
+    volatile uint32_t *pinsel = &LPC_PINCON->PINSEL0;
+    volatile uint32_t *pinmode = &LPC_PINCON->PINMODE0;
+    irqstatus_t flag = irq_save();
+    pinsel[bank_pos] = (pinsel[bank_pos] & mask) | sel_bits;
+    pinmode[bank_pos] = (pinmode[bank_pos] & mask) | mode;
+    irq_restore(flag);
+}
+
+// Convert a register and bit location back to an integer pin identifier
+static int
+regs_to_pin(LPC_GPIO_TypeDef *regs, uint32_t bit)
+{
+    int i;
+    for (i=0; i<ARRAY_SIZE(digital_regs); i++)
+        if (digital_regs[i] == regs)
+            return GPIO(i, ffs(bit)-1);
+    return 0;
+}
+
+
+/****************************************************************
+ * General Purpose Input Output (GPIO) pins
+ ****************************************************************/
+
+struct gpio_out
+gpio_out_setup(uint8_t pin, uint8_t val)
+{
+    if (GPIO2PORT(pin) >= ARRAY_SIZE(digital_regs))
+        goto fail;
+    LPC_GPIO_TypeDef *regs = digital_regs[GPIO2PORT(pin)];
+    struct gpio_out g = { .regs=regs, .bit=GPIO2BIT(pin) };
+    gpio_out_reset(g, val);
+    return g;
+fail:
+    shutdown("Not an output pin");
+}
+
+void
+gpio_out_reset(struct gpio_out g, uint8_t val)
+{
+    LPC_GPIO_TypeDef *regs = g.regs;
+    int pin = regs_to_pin(regs, g.bit);
+    irqstatus_t flag = irq_save();
+    regs->FIOPIN = (regs->FIOSET & ~g.bit) | (val ? g.bit : 0);
+    regs->FIODIR |= g.bit;
+    gpio_peripheral(pin, 0, 0);
+    irq_restore(flag);
+}
+
+void
+gpio_out_toggle_noirq(struct gpio_out g)
+{
+    LPC_GPIO_TypeDef *regs = g.regs;
+    regs->FIOPIN = regs->FIOSET ^ g.bit;
+}
+
+void
+gpio_out_toggle(struct gpio_out g)
+{
+    irqstatus_t flag = irq_save();
+    gpio_out_toggle_noirq(g);
+    irq_restore(flag);
+}
+
+void
+gpio_out_write(struct gpio_out g, uint8_t val)
+{
+    LPC_GPIO_TypeDef *regs = g.regs;
+    if (val)
+        regs->FIOSET = g.bit;
+    else
+        regs->FIOCLR = g.bit;
+}
+
+
+struct gpio_in
+gpio_in_setup(uint8_t pin, int8_t pull_up)
+{
+    if (GPIO2PORT(pin) >= ARRAY_SIZE(digital_regs))
+        goto fail;
+    LPC_GPIO_TypeDef *regs = digital_regs[GPIO2PORT(pin)];
+    struct gpio_in g = { .regs=regs, .bit=GPIO2BIT(pin) };
+    gpio_in_reset(g, pull_up);
+    return g;
+fail:
+    shutdown("Not an input pin");
+}
+
+void
+gpio_in_reset(struct gpio_in g, int8_t pull_up)
+{
+    LPC_GPIO_TypeDef *regs = g.regs;
+    int pin = regs_to_pin(regs, g.bit);
+    irqstatus_t flag = irq_save();
+    gpio_peripheral(pin, 0, pull_up);
+    regs->FIODIR &= ~g.bit;
+    irq_restore(flag);
+}
+
+uint8_t
+gpio_in_read(struct gpio_in g)
+{
+    LPC_GPIO_TypeDef *regs = g.regs;
+    return !!(regs->FIOPIN & g.bit);
+}

--- a/src/lpc176x/gpio.c
+++ b/src/lpc176x/gpio.c
@@ -64,14 +64,10 @@ regs_to_pin(LPC_GPIO_TypeDef *regs, uint32_t bit)
 struct gpio_out
 gpio_out_setup(uint8_t pin, uint8_t val)
 {
-    if (GPIO2PORT(pin) >= ARRAY_SIZE(digital_regs))
-        goto fail;
     LPC_GPIO_TypeDef *regs = digital_regs[GPIO2PORT(pin)];
     struct gpio_out g = { .regs=regs, .bit=GPIO2BIT(pin) };
     gpio_out_reset(g, val);
     return g;
-fail:
-    shutdown("Not an output pin");
 }
 
 void
@@ -115,14 +111,10 @@ gpio_out_write(struct gpio_out g, uint8_t val)
 struct gpio_in
 gpio_in_setup(uint8_t pin, int8_t pull_up)
 {
-    if (GPIO2PORT(pin) >= ARRAY_SIZE(digital_regs))
-        goto fail;
     LPC_GPIO_TypeDef *regs = digital_regs[GPIO2PORT(pin)];
     struct gpio_in g = { .regs=regs, .bit=GPIO2BIT(pin) };
     gpio_in_reset(g, pull_up);
     return g;
-fail:
-    shutdown("Not an input pin");
 }
 
 void

--- a/src/lpc176x/gpio.h
+++ b/src/lpc176x/gpio.h
@@ -1,0 +1,24 @@
+#ifndef __LPC176X_GPIO_H
+#define __LPC176X_GPIO_H
+
+#include <stdint.h>
+
+struct gpio_out {
+    void *regs;
+    uint32_t bit;
+};
+struct gpio_out gpio_out_setup(uint8_t pin, uint8_t val);
+void gpio_out_reset(struct gpio_out g, uint8_t val);
+void gpio_out_toggle_noirq(struct gpio_out g);
+void gpio_out_toggle(struct gpio_out g);
+void gpio_out_write(struct gpio_out g, uint8_t val);
+
+struct gpio_in {
+    void *regs;
+    uint32_t bit;
+};
+struct gpio_in gpio_in_setup(uint8_t pin, int8_t pull_up);
+void gpio_in_reset(struct gpio_in g, int8_t pull_up);
+uint8_t gpio_in_read(struct gpio_in g);
+
+#endif // gpio.h

--- a/src/lpc176x/internal.h
+++ b/src/lpc176x/internal.h
@@ -1,0 +1,27 @@
+#ifndef __LPC176X_INTERNAL_H
+#define __LPC176X_INTERNAL_H
+// Local definitions for lpc176x code
+
+#include "LPC17xx.h"
+
+#define GPIO(PORT, NUM) ((PORT) * 32 + (NUM))
+#define GPIO2PORT(PIN) ((PIN) / 32)
+#define GPIO2BIT(PIN) (1<<((PIN) % 32))
+
+#define PCLK_TIMER0 1
+#define PCLK_UART0 3
+#define PCLK_PWM1 6
+#define PCLK_I2C0 7
+#define PCLK_SSP1 10
+#define PCLK_ADC 12
+#define PCLK_I2C1 19
+#define PCLK_SSP0 21
+#define PCLK_UART3 25
+#define PCLK_I2C2 26
+#define PCLK_USB 31
+int is_enabled_pclock(uint32_t pclk);
+void enable_pclock(uint32_t pclk);
+uint32_t get_pclock_frequency(uint32_t pclk);
+void gpio_peripheral(uint32_t gpio, int func, int pullup);
+
+#endif // internal.h

--- a/src/lpc176x/main.c
+++ b/src/lpc176x/main.c
@@ -1,0 +1,67 @@
+// Main starting point for LPC176x boards.
+//
+// Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "autoconf.h" // CONFIG_CLOCK_FREQ
+#include "board/armcm_boot.h" // armcm_main
+#include "internal.h" // enable_pclock
+#include "sched.h" // sched_main
+
+
+/****************************************************************
+ * watchdog handler
+ ****************************************************************/
+
+void
+watchdog_reset(void)
+{
+    LPC_WDT->WDFEED = 0xaa;
+    LPC_WDT->WDFEED = 0x55;
+}
+DECL_TASK(watchdog_reset);
+
+void
+watchdog_init(void)
+{
+    LPC_WDT->WDTC = 4000000 / 2; // 500ms timeout
+    LPC_WDT->WDCLKSEL = 1<<31; // Lock to internal RC
+    LPC_WDT->WDMOD = 0x03; // select reset and enable
+    watchdog_reset();
+}
+DECL_INIT(watchdog_init);
+
+
+/****************************************************************
+ * misc functions
+ ****************************************************************/
+
+// Check if a peripheral clock has been enabled
+int
+is_enabled_pclock(uint32_t pclk)
+{
+    return !!(LPC_SC->PCONP & (1<<pclk));
+}
+
+// Enable a peripheral clock
+void
+enable_pclock(uint32_t pclk)
+{
+    LPC_SC->PCONP |= 1<<pclk;
+}
+
+// Return the frequency of the given peripheral clock
+uint32_t
+get_pclock_frequency(uint32_t pclk)
+{
+    return CONFIG_CLOCK_FREQ;
+}
+
+// Main entry point - called from armcm_boot.c:ResetHandler()
+void
+armcm_main(void)
+{
+    SystemInit();
+    sched_main();
+}

--- a/src/lpc176x/serial.c
+++ b/src/lpc176x/serial.c
@@ -1,0 +1,98 @@
+// lpc176x serial port
+//
+// Copyright (C) 2018-2021  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include "board/armcm_boot.h" // armcm_enable_irq
+#include "autoconf.h" // CONFIG_SERIAL_BAUD
+#include "board/irq.h" // irq_save
+#include "board/serial_irq.h" // serial_rx_data
+#include "command.h" // DECL_CONSTANT_STR
+#include "internal.h" // gpio_peripheral
+#include "sched.h" // DECL_INIT
+
+#if CONFIG_LPC_SERIAL_UART0_P03_P02
+  DECL_CONSTANT_STR("RESERVE_PINS_serial", "P0.3,P0.2");
+  #define GPIO_Rx GPIO(0, 3)
+  #define GPIO_Tx GPIO(0, 2)
+  #define GPIO_FUNCTION_UARTx 1
+  #define LPC_UARTx LPC_UART0
+  #define UARTx_IRQn UART0_IRQn
+  #define PCLK_UARTx PCLK_UART0
+#elif CONFIG_LPC_SERIAL_UART3_P429_P428
+  DECL_CONSTANT_STR("RESERVE_PINS_serial", "P4.29,P4.28");
+  #define GPIO_Rx GPIO(4, 29)
+  #define GPIO_Tx GPIO(4, 28)
+  #define GPIO_FUNCTION_UARTx 3
+  #define LPC_UARTx LPC_UART3
+  #define UARTx_IRQn UART3_IRQn
+  #define PCLK_UARTx PCLK_UART3
+#endif
+
+// Write tx bytes to the serial port
+static void
+kick_tx(void)
+{
+    for (;;) {
+        if (!(LPC_UARTx->LSR & (1<<5))) {
+            // Output fifo full - enable tx irq
+            LPC_UARTx->IER = 0x03;
+            break;
+        }
+        uint8_t data;
+        int ret = serial_get_tx_byte(&data);
+        if (ret) {
+            // No more data to send - disable tx irq
+            LPC_UARTx->IER = 0x01;
+            break;
+        }
+        LPC_UARTx->THR = data;
+    }
+}
+
+void
+UARTx_IRQHandler(void)
+{
+    uint32_t iir = LPC_UARTx->IIR, status = iir & 0x0f;
+    if (status == 0x04)
+        serial_rx_byte(LPC_UARTx->RBR);
+    else if (status == 0x02)
+        kick_tx();
+}
+
+void
+serial_enable_tx_irq(void)
+{
+    if (LPC_UARTx->LSR & (1<<5)) {
+        irqstatus_t flag = irq_save();
+        kick_tx();
+        irq_restore(flag);
+    }
+}
+
+void
+serial_init(void)
+{
+    // Setup baud
+    enable_pclock(PCLK_UARTx);
+    LPC_UARTx->LCR = (1<<7); // set DLAB bit
+    uint32_t pclk = get_pclock_frequency(PCLK_UARTx);
+    uint32_t div = pclk / (CONFIG_SERIAL_BAUD * 16);
+    LPC_UARTx->DLL = div & 0xff;
+    LPC_UARTx->DLM = (div >> 8) & 0xff;
+    LPC_UARTx->FDR = 0x10;
+    LPC_UARTx->LCR = 3; // 8N1 ; clear DLAB bit
+
+    // Enable fifo
+    LPC_UARTx->FCR = 0x01;
+
+    // Setup pins
+    gpio_peripheral(GPIO_Rx, GPIO_FUNCTION_UARTx, 0);
+    gpio_peripheral(GPIO_Tx, GPIO_FUNCTION_UARTx, 0);
+
+    // Enable receive irq
+    armcm_enable_irq(UARTx_IRQHandler, UARTx_IRQn, 0);
+    LPC_UARTx->IER = 0x01;
+}
+DECL_INIT(serial_init);

--- a/src/lpc176x/usb_cdc_ep.h
+++ b/src/lpc176x/usb_cdc_ep.h
@@ -1,0 +1,10 @@
+#ifndef __LPC176X_USB_CDC_EP_H
+#define __LPC176X_USB_CDC_EP_H
+
+enum {
+    USB_CDC_EP_ACM = 1,
+    USB_CDC_EP_BULK_OUT = 2,
+    USB_CDC_EP_BULK_IN = 5,
+};
+
+#endif // usb_cdc_ep.h

--- a/src/lpc176x/usbserial.c
+++ b/src/lpc176x/usbserial.c
@@ -1,0 +1,330 @@
+// Hardware interface to USB on lpc176x
+//
+// Copyright (C) 2018  Kevin O'Connor <kevin@koconnor.net>
+//
+// This file may be distributed under the terms of the GNU GPLv3 license.
+
+#include <string.h> // memcpy
+#include "autoconf.h" // CONFIG_SMOOTHIEWARE_BOOTLOADER
+#include "board/armcm_boot.h" // armcm_enable_irq
+#include "board/irq.h" // irq_disable
+#include "board/misc.h" // timer_read_time
+#include "generic/usb_cdc.h" // usb_notify_ep0
+#include "byteorder.h" // cpu_to_le32
+#include "command.h" // DECL_CONSTANT_STR
+#include "internal.h" // gpio_peripheral
+#include "sched.h" // DECL_INIT
+#include "usb_cdc_ep.h" // USB_CDC_EP_BULK_IN
+
+// Internal endpoint addresses
+#define EP0OUT 0x00
+#define EP0IN 0x01
+#define EP1IN 0x03
+#define EP2OUT 0x04
+#define EP5IN 0x0b
+
+// USB device interupt status flags
+#define EP_SLOW (1<<2)
+#define DEV_STAT (1<<3)
+#define CCEMPTY (1<<4)
+#define CDFULL (1<<5)
+#define EP_RLZED (1<<8)
+
+#define RD_EN (1<<0)
+#define WR_EN (1<<1)
+
+static void
+usb_irq_disable(void)
+{
+    NVIC_DisableIRQ(USB_IRQn);
+}
+
+static void
+usb_irq_enable(void)
+{
+    NVIC_EnableIRQ(USB_IRQn);
+}
+
+static void
+usb_wait(uint32_t flag)
+{
+    while (!(LPC_USB->USBDevIntSt & flag))
+        ;
+    LPC_USB->USBDevIntClr = flag;
+}
+
+
+/****************************************************************
+ * Serial Interface Engine (SIE) functions
+ ****************************************************************/
+
+#define SIE_CMD_SELECT 0x00
+#define SIE_CMD_SET_ENDPOINT_STATUS 0x40
+#define SIE_CMD_SET_ADDRESS 0xD0
+#define SIE_CMD_CONFIGURE 0xD8
+#define SIE_CMD_SET_DEVICE_STATUS 0xFE
+#define SIE_CMD_CLEAR_BUFFER 0xF2
+#define SIE_CMD_VALIDATE_BUFFER 0xFA
+
+static void
+sie_cmd(uint32_t cmd)
+{
+    LPC_USB->USBDevIntClr = CDFULL | CCEMPTY;
+    LPC_USB->USBCmdCode = 0x00000500 | (cmd << 16);
+    usb_wait(CCEMPTY);
+}
+
+static void
+sie_cmd_write(uint32_t cmd, uint32_t data)
+{
+    sie_cmd(cmd);
+    LPC_USB->USBCmdCode = 0x00000100 | (data << 16);
+    usb_wait(CCEMPTY);
+}
+
+static uint32_t
+sie_cmd_read(uint32_t cmd)
+{
+    sie_cmd(cmd);
+    LPC_USB->USBCmdCode = 0x00000200 | (cmd << 16);
+    usb_wait(CDFULL);
+    return LPC_USB->USBCmdData;
+}
+
+static uint32_t
+sie_select_and_clear(uint32_t idx)
+{
+    LPC_USB->USBEpIntClr = 1<<idx;
+    usb_wait(CDFULL);
+    return LPC_USB->USBCmdData;
+}
+
+
+/****************************************************************
+ * Interface
+ ****************************************************************/
+
+static int_fast8_t
+usb_write_packet(uint32_t ep, const void *data, uint_fast8_t len)
+{
+    usb_irq_disable();
+    uint32_t sts = sie_cmd_read(SIE_CMD_SELECT | ep);
+    if (sts & 0x01) {
+        // Output buffers full
+        usb_irq_enable();
+        return -1;
+    }
+
+    LPC_USB->USBCtrl = WR_EN | ((ep/2) << 2);
+    LPC_USB->USBTxPLen = len;
+    if (!len)
+        LPC_USB->USBTxData = 0;
+    int i;
+    for (i = 0; i<DIV_ROUND_UP(len, 4); i++) {
+        uint32_t d;
+        memcpy(&d, data, sizeof(d));
+        data += sizeof(d);
+        LPC_USB->USBTxData = cpu_to_le32(d);
+    }
+    sie_cmd(SIE_CMD_VALIDATE_BUFFER);
+    usb_irq_enable();
+
+    return len;
+}
+
+static int_fast8_t
+usb_read_packet(uint32_t ep, void *data, uint_fast8_t max_len)
+{
+    usb_irq_disable();
+    uint32_t sts = sie_cmd_read(SIE_CMD_SELECT | ep);
+    if (!(sts & 0x01)) {
+        // No data available
+        usb_irq_enable();
+        return -1;
+    }
+
+    // Determine packet size
+    LPC_USB->USBCtrl = RD_EN | ((ep/2) << 2);
+    uint32_t plen = LPC_USB->USBRxPLen;
+    while (!(plen & (1<<11)))
+        plen = LPC_USB->USBRxPLen;
+    plen &= 0x3FF;
+    if (plen > max_len)
+        // XXX - return error code?  must keep reading?
+        plen = max_len;
+    // Copy data
+    uint32_t xfer = plen;
+    for (;;) {
+        uint32_t d = le32_to_cpu(LPC_USB->USBRxData);
+        if (xfer <= sizeof(d)) {
+            memcpy(data, &d, xfer);
+            break;
+        }
+        memcpy(data, &d, sizeof(d));
+        data += sizeof(d);
+        xfer -= sizeof(d);
+    }
+    // Clear space for next packet
+    sts = sie_cmd_read(SIE_CMD_CLEAR_BUFFER);
+    usb_irq_enable();
+    if (sts & 0x01)
+        // Packet overwritten
+        return -1;
+
+    return plen;
+}
+
+int_fast8_t
+usb_read_bulk_out(void *data, uint_fast8_t max_len)
+{
+    return usb_read_packet(EP2OUT, data, max_len);
+}
+
+int_fast8_t
+usb_send_bulk_in(void *data, uint_fast8_t len)
+{
+    return usb_write_packet(EP5IN, data, len);
+}
+
+int_fast8_t
+usb_read_ep0(void *data, uint_fast8_t max_len)
+{
+    return usb_read_packet(EP0OUT, data, max_len);
+}
+
+int_fast8_t
+usb_read_ep0_setup(void *data, uint_fast8_t max_len)
+{
+    return usb_read_ep0(data, max_len);
+}
+
+int_fast8_t
+usb_send_ep0(const void *data, uint_fast8_t len)
+{
+    return usb_write_packet(EP0IN, data, len);
+}
+
+void
+usb_stall_ep0(void)
+{
+    usb_irq_disable();
+    sie_cmd_write(SIE_CMD_SET_ENDPOINT_STATUS | 0, (1<<7));
+    usb_irq_enable();
+}
+
+void
+usb_set_address(uint_fast8_t addr)
+{
+    usb_irq_disable();
+    sie_cmd_write(SIE_CMD_SET_ADDRESS, addr | (1<<7));
+    usb_irq_enable();
+    usb_send_ep0(NULL, 0);
+}
+
+static void
+realize_endpoint(uint32_t idx, uint32_t packet_size)
+{
+    LPC_USB->USBDevIntClr = EP_RLZED;
+    LPC_USB->USBReEp |= 1<<idx;
+    LPC_USB->USBEpInd = idx;
+    LPC_USB->USBMaxPSize = packet_size;
+    usb_wait(EP_RLZED);
+    LPC_USB->USBEpIntEn |= 1<<idx;
+    sie_cmd_write(SIE_CMD_SET_ENDPOINT_STATUS | idx, 0);
+}
+
+void
+usb_set_configure(void)
+{
+    usb_irq_disable();
+    realize_endpoint(EP1IN, USB_CDC_EP_ACM_SIZE);
+    realize_endpoint(EP2OUT, USB_CDC_EP_BULK_OUT_SIZE);
+    realize_endpoint(EP5IN, USB_CDC_EP_BULK_IN_SIZE);
+    sie_cmd_write(SIE_CMD_CONFIGURE, 1);
+    usb_irq_enable();
+}
+
+void
+usb_request_bootloader(void)
+{
+    if (!CONFIG_SMOOTHIEWARE_BOOTLOADER)
+        return;
+    // Disable USB and pause for 5ms so host recognizes a disconnect
+    irq_disable();
+    sie_cmd_write(SIE_CMD_SET_DEVICE_STATUS, 0);
+    udelay(5000);
+    // The "LPC17xx-DFU-Bootloader" will enter the bootloader if the
+    // watchdog timeout flag is set.
+    LPC_WDT->WDMOD = 0x07;
+    NVIC_SystemReset();
+}
+
+
+/****************************************************************
+ * Setup and interrupts
+ ****************************************************************/
+
+void
+USB_IRQHandler(void)
+{
+    uint32_t udis = LPC_USB->USBDevIntSt;
+    if (udis & DEV_STAT) {
+        LPC_USB->USBDevIntClr = DEV_STAT;
+        // XXX - should handle reset and other states
+    }
+    if (udis & EP_SLOW) {
+        uint32_t ueis = LPC_USB->USBEpIntSt;
+        if (ueis & (1<<EP0OUT)) {
+            sie_select_and_clear(EP0OUT);
+            usb_notify_ep0();
+        }
+        if (ueis & (1<<EP0IN)) {
+            sie_select_and_clear(EP0IN);
+            usb_notify_ep0();
+        }
+        if (ueis & (1<<EP2OUT)) {
+            sie_select_and_clear(EP2OUT);
+            usb_notify_bulk_out();
+        }
+        if (ueis & (1<<EP5IN)) {
+            sie_select_and_clear(EP5IN);
+            usb_notify_bulk_in();
+        }
+        LPC_USB->USBDevIntClr = EP_SLOW;
+    }
+}
+
+DECL_CONSTANT_STR("RESERVE_PINS_USB", "P0.30,P0.29,P2.9");
+
+void
+usbserial_init(void)
+{
+    usb_irq_disable();
+    // enable power
+    enable_pclock(PCLK_USB);
+    // enable clock
+    LPC_USB->USBClkCtrl = 0x12;
+    while (LPC_USB->USBClkSt != 0x12)
+        ;
+    // configure USBD-, USBD+, and USB Connect pins
+    gpio_peripheral(GPIO(0, 30), 1, 0);
+    gpio_peripheral(GPIO(0, 29), 1, 0);
+    gpio_peripheral(GPIO(2, 9), 1, 0);
+    // enforce a minimum time bus is disconnected before connecting
+    udelay(5000);
+    // setup endpoints
+    realize_endpoint(EP0OUT, USB_CDC_EP0_SIZE);
+    realize_endpoint(EP0IN, USB_CDC_EP0_SIZE);
+    sie_cmd_write(SIE_CMD_SET_DEVICE_STATUS, 1);
+    // enable irqs
+    LPC_USB->USBDevIntEn = DEV_STAT | EP_SLOW;
+    armcm_enable_irq(USB_IRQHandler, USB_IRQn, 1);
+}
+DECL_INIT(usbserial_init);
+
+void
+usbserial_shutdown(void)
+{
+    usb_irq_enable();
+}
+DECL_SHUTDOWN(usbserial_shutdown);

--- a/src/lpc176x/usbserial.c
+++ b/src/lpc176x/usbserial.c
@@ -244,22 +244,6 @@ usb_set_configure(void)
     usb_irq_enable();
 }
 
-void
-usb_request_bootloader(void)
-{
-    if (!CONFIG_SMOOTHIEWARE_BOOTLOADER)
-        return;
-    // Disable USB and pause for 5ms so host recognizes a disconnect
-    irq_disable();
-    sie_cmd_write(SIE_CMD_SET_DEVICE_STATUS, 0);
-    udelay(5000);
-    // The "LPC17xx-DFU-Bootloader" will enter the bootloader if the
-    // watchdog timeout flag is set.
-    LPC_WDT->WDMOD = 0x07;
-    NVIC_SystemReset();
-}
-
-
 /****************************************************************
  * Setup and interrupts
  ****************************************************************/


### PR DESCRIPTION
This adds experimental support for the lpc1768 (and hopefully lpc1769) MCUs.   There are some things I discovered with this implementation, and thus there may need to be some refactoring before I merge.

- As previously mentioned, the IAP write addresses must be on a 256 byte boundary.  Rather than increase block size (and thus the size of the rx and tx buffers) I just buffered the data in flash.c.  That said, I worked the implementation to accept a larger block size and skip the buffer if we want to move in that direction.
- I noticed that the `FLASHTIM` field in the `FLASHCFG` register was set to 3.  According to the datasheet this should be set to 4 for 100MHz (and 120MHz) processors.  I changed that since my assumption is the bootloader is going to require the "flash accelerator" to be reliable.
- `__VTOR_PRESENT` was not defined in the lpc headers, thus the jump failed during my initial tests.  I added it to `internal.h`, however I noticed that only the stm32g0 headers seem to have this definition.  Presumably the jump to Klipper still works for STM32 devices because Klipper explicitly sets the vector table.  It might be wise to make sure that the bootloader sets the vector table for all devices that support it.
- This last one is a bit of a gotcha.  It appears the the lpc176x boot ROM writes to SRAM on every reset.  Initially it was overwriting CanBoot's "bootup code".  I found an area in SRAM that wasn't modified and moved the stack a bit by reducing the ram size.  It works on my device, however I'm a bit concerned about the reliability of this solution. 