### PR TITLE
Wait 100ms before overwriting existing bootloader in deployer

### DIFF
--- a/src/deployer.c
+++ b/src/deployer.c
@@ -77,6 +77,10 @@ sched_main(void)
         halt();
     }
 
+    // Wait 100ms to help ensure power supply is stable before
+    // overwriting existing bootloader
+    udelay(100000);
+
     // Write CanBoot to flash
     const uint8_t *p = deployer_canboot_binary, *end = &p[cbsize];
     while (p < end) {


### PR DESCRIPTION
I was changing over my huvud 0.50 boards from "hid bootloader" to CanBoot using the "deployer" function.  Unfortunately, I ran into an issue where CanBoot failed to deploy and the board was left without a functional bootloader.  I connected openocd to the swd lines and dumped the flash.  It showed that the deploy tool failed after flashing 1356 bytes of the total 3590 bytes.  It looks like the reset line was glitching (likely when I was applying the reset jumper on the huvud 0.50 board) which caused the mcu to restart many times in a short period.  It looks like the deployer got far enough into its processing to erase the existing bootloader, but didn't get enough time to fully flash the new binary before a reset occurred.

To avoid this type of failure, this PR adds a 100ms delay before the deployer will erase the existing bootloader.  Ideally, this will help ensure the mcu power/reset lines are stable before the flash is erased.

-Kevin