### PR TITLE
Don't consider a reset in less than 10ms a double click

### DIFF
--- a/src/bootentry.c
+++ b/src/bootentry.c
@@ -28,18 +28,22 @@ check_button_pressed(void)
     return gpio_in_read(button) == button_high;
 }
 
+#define DOUBLE_CLICK_MIN_US 10000
+#define DOUBLE_CLICK_MAX_US 500000
+
 // Check for a bootloader request via double tap of reset button
 static void
 check_double_reset(void)
 {
     if (!CONFIG_ENABLE_DOUBLE_RESET)
         return;
-    // set request signature and delay for two seconds.  This enters the bootloader if
+    // Set request signature and delay - this enters the bootloader if
     // the reset button is double clicked
+    udelay(DOUBLE_CLICK_MIN_US);
     set_bootup_code(REQUEST_CANBOOT);
-    udelay(500000);
+    udelay(DOUBLE_CLICK_MAX_US - DOUBLE_CLICK_MIN_US);
+    // No reset, clear the bootup code
     set_bootup_code(0);
-    // No reset, read the key back out to clear it
 }
 
 // Check if bootloader or application should be started


### PR DESCRIPTION
I have an lpc1768 test board that always seems to enter CanBoot when first powered on.  It seems that when the board first powers up the power may not be fully stable and it can result in one or more resets in the first few milliseconds.  Changing CanBoot to ignore resets in the first 10ms fixes this for me.  Thus, after this PR, to enter the bootloader, the "double click" time must be between 10ms and 500ms.

-Kevin