### PR TITLE
Fix "Unable to bind socket" text with non-can0 interfaces

### DIFF
--- a/scripts/flash_can.py
+++ b/scripts/flash_can.py
@@ -446,7 +446,7 @@ class CanSocket:
         try:
             self.cansock.bind((intf,))
         except Exception:
-            raise FlashCanError("Unable to bind socket to can0")
+            raise FlashCanError("Unable to bind socket to %s" % (intf))
         self.closed = False
         self.cansock.setblocking(False)
         self._loop.add_reader(


### PR DESCRIPTION
Simple one-line fix