### PR TITLE
flash.c: fix write error for STM32H72x

### DIFF
--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -218,13 +218,15 @@ flash_write_block(uint32_t block_address, uint32_t *data)
     unlock_flash();
 
     // Erase page
-    if (need_erase)
+    if (need_erase) {
         erase_page(page_address);
 
-    // avoid triggering STM32H72xx write security
-    lock_flash();
-    unlock_flash();
-
+        // avoid triggering STM32H72xx write security
+        if (CONFIG_MACH_STM32H7) {
+            lock_flash();
+            unlock_flash();
+        }
+    }
     // Write block
     write_block(block_address, data);
 

--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -221,6 +221,10 @@ flash_write_block(uint32_t block_address, uint32_t *data)
     if (need_erase)
         erase_page(page_address);
 
+    // avoid triggering STM32H72xx write security
+    lock_flash();
+    unlock_flash();
+
     // Write block
     write_block(block_address, data);
 


### PR DESCRIPTION
Issue: CanBoot and the deployer were able to erase memory but not to write it write right afterwards on STM32F723.
Fix: Add a flash lock/unlock sequence after erasing and before writing to the flash memory in flash_write_block(). Shouldn't be destructive for the other supported STM32 processors.
Tested on STM32H723, STM32H743 and STM32F407.

Signed off by: Robin Gay <robingay67@gmail.com>