### PR TITLE
stm32: add STM32G474 support

### DIFF
--- a/src/stm32/Kconfig
+++ b/src/stm32/Kconfig
@@ -75,6 +75,9 @@ choice
     config MACH_STM32G431
         bool "STM32G431"
         select MACH_STM32G4
+    config MACH_STM32G474
+        bool "STM32G474"
+        select MACH_STM32G4
     config MACH_STM32H723
         bool "STM32H723"
         select MACH_STM32H7
@@ -147,6 +150,7 @@ config MCU
     default "stm32g0b0xx" if MACH_STM32G0B0
     default "stm32g0b1xx" if MACH_STM32G0B1
     default "stm32g431xx" if MACH_STM32G431
+    default "stm32g474xx" if MACH_STM32G474
     default "stm32h723xx" if MACH_STM32H723
     default "stm32h743xx" if MACH_STM32H743
     default "stm32h750xx" if MACH_STM32H750
@@ -162,7 +166,7 @@ config CLOCK_FREQ
     default 168000000 if MACH_STM32F4x5
     default 180000000 if MACH_STM32F446
     default 64000000 if MACH_STM32G0
-    default 150000000 if MACH_STM32G431
+    default 150000000 if MACH_STM32G431 || MACH_STM32G474
     default 400000000 if MACH_STM32H7 && !MACH_STM32H750
     default 480000000 if MACH_STM32H750
     default 80000000 if MACH_STM32L412
@@ -176,6 +180,7 @@ config FLASH_SIZE
     default 0x40000 if MACH_STM32F2 || MACH_STM32F401 || MACH_STM32H723
     default 0x80000 if MACH_STM32F4x5 || MACH_STM32F446
     default 0x20000 if MACH_STM32G0 || MACH_STM32G431
+    default 0x80000 if MACH_STM32G474
     default 0x20000 if MACH_STM32H750
     default 0x200000 if MACH_STM32H743
 
@@ -196,6 +201,7 @@ config RAM_SIZE
     default 0x2800 if MACH_STM32F103x6
     default 0x5000 if MACH_STM32F103 && !MACH_STM32F103x6 # Ram size of stm32f103x8
     default 0x8000 if MACH_STM32G431
+    default 0x20000 if MACH_STM32G474
     default 0xa000 if MACH_STM32L412
     default 0x20000 if MACH_STM32F207
     default 0x10000 if MACH_STM32F401
@@ -406,15 +412,15 @@ choice
         select CANSERIAL
     config STM32_MMENU_CANBUS_PB0_PB1
         bool "CAN bus (on PB0/PB1)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
         select CANSERIAL
     config STM32_MMENU_CANBUS_PD12_PD13
         bool "CAN bus (on PD12/PD13)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
         select CANSERIAL
     config STM32_MMENU_CANBUS_PC2_PC3
         bool "CAN bus (on PC2/PC3)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
         select CANSERIAL
     config STM32_MMENU_CANBUS_PH13_PH14
         bool "CAN bus (on PH13/PH14)" if MACH_STM32H743
@@ -443,13 +449,13 @@ choice
         depends on HAVE_STM32_CANBUS || HAVE_STM32_FDCANBUS
     config STM32_CMENU_CANBUS_PB0_PB1
         bool "CAN bus (on PB0/PB1)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
     config STM32_CMENU_CANBUS_PD12_PD13
         bool "CAN bus (on PD12/PD13)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
     config STM32_CMENU_CANBUS_PC2_PC3
         bool "CAN bus (on PC2/PC3)"
-        depends on HAVE_STM32_FDCANBUS
+        depends on HAVE_STM32_FDCANBUS && !MACH_STM32G4
     config STM32_CMENU_CANBUS_PH13_PH14
         bool "CAN bus (on PH13/PH14)" if MACH_STM32H743
         depends on HAVE_STM32_FDCANBUS

--- a/src/stm32/flash.c
+++ b/src/stm32/flash.c
@@ -32,7 +32,18 @@ flash_get_page_size(uint32_t addr)
             return 2 * 1024;
         uint16_t *flash_size = (void*)FLASHSIZE_BASE;
         return *flash_size <= 64 ? 1024 : 2 * 1024;
-    } else if (CONFIG_MACH_STM32G0 || CONFIG_MACH_STM32G4) {
+    } else if (CONFIG_MACH_STM32G0) {
+        return 2 * 1024;
+    } else if (CONFIG_MACH_STM32G4) {
+        // G474xE in single-bank mode (DBANK=0, default) uses 4KB pages;
+        // all other G4 devices and G474xE in dual-bank mode use 2KB pages.
+#if defined(FLASH_OPTR_DBANK)
+        if (!(FLASH->OPTR & FLASH_OPTR_DBANK)) {
+            uint16_t *flash_size = (void*)FLASHSIZE_BASE;
+            if (*flash_size > 256)
+                return 4 * 1024;
+        }
+#endif
         return 2 * 1024;
     } else if (CONFIG_MACH_STM32H7) {
         return 128 * 1024;
@@ -110,7 +121,7 @@ erase_page(uint32_t page_address)
     FLASH->CR = FLASH_CR_PER;
     FLASH->AR = page_address;
     FLASH->CR = FLASH_CR_PER | FLASH_CR_STRT;
-#elif CONFIG_MACH_STM32G0 || CONFIG_MACH_STM32G4
+#elif CONFIG_MACH_STM32G0
     uint32_t pidx = (page_address - 0x08000000) / (2 * 1024);
     if (pidx >= 64) {
         uint16_t *flash_size = (void*)FLASHSIZE_BASE;
@@ -120,6 +131,11 @@ erase_page(uint32_t page_address)
             pidx = pidx < 128 ? pidx : pidx + 256 - 128;
     }
     pidx = pidx > 0x3ff ? 0x3ff : pidx;
+    FLASH->CR = FLASH_CR_PER | FLASH_CR_STRT | (pidx << FLASH_CR_PNB_Pos);
+#elif CONFIG_MACH_STM32G4
+    uint32_t page_size = flash_get_page_size(page_address);
+    uint32_t pidx = (page_address - 0x08000000) / page_size;
+    pidx = pidx > 0x7f ? 0x7f : pidx;
     FLASH->CR = FLASH_CR_PER | FLASH_CR_STRT | (pidx << FLASH_CR_PNB_Pos);
 #elif CONFIG_MACH_STM32H7
     uint32_t snb = (page_address - 0x08000000) / (128 * 1024);


### PR DESCRIPTION
Add STM32G474 to the processor selection and fix the flash erase logic in flash.c to support all G474 variants (single-bank mode only).

Kconfig changes (stm32g474xx, 150MHz PLL, 512KB flash, 128KB RAM):
- FLASH_SIZE 0x80000 covers the xE variant (most common);
- RAM_SIZE 0x20000: SRAM1+SRAM2+SRAM3 are contiguous at 0x20000000.

flash.c - separate G0 and G4 erase paths:
- G474xB/xC (128/256KB): 2KB pages, direct PNB index;
- G474xE single-bank (DBANK=0, factory default): 4KB pages, detected at runtime via FLASH->OPTR FLASH_OPTR_DBANK bit;
- Removes incorrect G0 dual-bank arithmetic that was previously shared with G4, which corrupted page indices for addresses above 128KB.

Kconfig: hide FDCAN pin options invalid on G4 (PB0/PB1, PD12/PD13, PC2/PC3 have no FDCAN alternate function on STM32G4 devices).

Tested on WeAct STM32G474 board (STM32G474CEU6, 512 KB flash variant):
- USB communication: verified flashing Klipper via Katapult and connecting over USB;
- Flash write/read integrity: verified correct erase and write of flash pages above address 0x8040000 (pages 64+, affected by the G0 dual-bank arithmetic fix) by flashing a 300 KB random binary and reading it back via ST-Link;
- USB-to-CAN bridge mode: verified that canbus_uuid is reported correctly;
- CAN communication: not yet tested due to the absence of a transceiver.

Signed-off-by:  Oleksii Sliesarevych <aslesar07@gmail.com>