### PR TITLE
feat(stm32): add DFU command to reboot into ROM DFU bootloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ options:
   -v, --verbose         Enable verbose responses
   -r, --request-bootloader
                         Requests the bootloader and exits
+  --request-dfu         Requests the device reboot into ROM DFU mode and exits
   -s, --status          Connect to bootloader and print status
 ```
 
@@ -182,6 +183,26 @@ bridge mode". These devices upload firmware using DFU and/or Katapult-USB. This
 option allows the user to enter the bootloader without physical access to the
 board, then use the appropriate tool (`dfu-util` or `flashtool.py -d`) to
 upload the new binary.
+
+### Request ROM DFU Bootloader and Exit
+
+When the `--request-dfu` option is supplied `flashtool` asks Katapult to
+reboot the MCU into the ROM DFU bootloader (e.g. `0483:df11` on STM32).
+Flashtool will then immediately exit; use `dfu-util` to upload a new binary.
+
+This is only needed when updating **Katapult itself** on a board whose
+BOOT0/RESET buttons are inaccessible — application firmware (i.e. Klipper)
+should be flashed through Katapult as usual and never requires DFU.
+
+The option works over both transports: with `-d <serial device>` a device
+running Klipper is first rebooted into Katapult, then asked to enter DFU;
+with `-i <interface> -u <uuid>` the same applies, including "USB to CAN
+bridge mode" devices (flashtool follows the bridge to its Katapult USB serial
+device automatically).
+
+Requires Katapult built from a source tree that includes DFU support on an
+STM32 with a USB-capable ROM bootloader. When unsupported, the request is
+rejected and the device remains in the bootloader.
 
 Additionally, the `-r` option can be used with devices connected to the host
 over a UART connection to request Klipper's bootloader.

--- a/scripts/flashtool.py
+++ b/scripts/flashtool.py
@@ -61,7 +61,8 @@ BOOTLOADER_CMDS = {
     'SEND_EOF': 0x13,
     'REQUEST_BLOCK': 0x14,
     'COMPLETE': 0x15,
-    'GET_CANBUS_ID': 0x16
+    'GET_CANBUS_ID': 0x16,
+    'DFU': 0x17
 }
 
 ACK_SUCCESS = 0xa0
@@ -492,6 +493,11 @@ class CanFlasher:
     async def finish(self):
         await self.send_command("COMPLETE")
 
+    async def request_dfu(self):
+        output_line("Requesting reboot into ROM DFU mode...")
+        await self.send_command("DFU")
+        output_line("DFU request acknowledged")
+
 
 class CanNode:
     def __init__(self, node_id: int, cansocket: CanSocket | SerialSocket) -> None:
@@ -544,11 +550,16 @@ class BaseSocket:
     def is_flash_req(self) -> bool:
         return not (
             self.is_bootloader_req or self.is_status_req or self.is_query
+            or self.is_dfu_req
         )
 
     @property
     def is_bootloader_req(self) -> bool:
         return self._args.request_bootloader
+
+    @property
+    def is_dfu_req(self) -> bool:
+        return self._args.request_dfu
 
     @property
     def is_status_req(self) -> bool:
@@ -819,7 +830,7 @@ class CanSocket(BaseSocket):
         self.cansock.setblocking(False)
         self._loop.add_reader(
             self.cansock.fileno(), self._handle_can_response)
-        if self.is_flash_req or self.is_bootloader_req:
+        if self.is_flash_req or self.is_bootloader_req or self.is_dfu_req:
             self._jump_to_bootloader(self._uuid)
             if self.is_usb_can_bridge:
                 await self._wait_canbridge_reset()
@@ -839,6 +850,9 @@ class CanSocket(BaseSocket):
         try:
             await flasher.connect_btl()
             await flasher.verify_canbus_uuid(self._uuid)
+            if self.is_dfu_req:
+                await flasher.request_dfu()
+                return
             if not self.is_status_req:
                 await flasher.send_file()
                 await flasher.verify_file()
@@ -1074,6 +1088,9 @@ class SerialSocket(BaseSocket):
                 # to respond immediately to the connect command.
                 flasher.prime()
             await flasher.connect_btl()
+            if self.is_dfu_req:
+                await flasher.request_dfu()
+                return
             if not self.is_status_req:
                 await flasher.send_file()
                 await flasher.verify_file()
@@ -1119,6 +1136,8 @@ async def main(args: argparse.Namespace) -> int:
         output_line("CANBus UUID Query Complete")
     elif sock.is_bootloader_req:
         output_line("Bootloader Request Complete")
+    elif sock.is_dfu_req:
+        output_line("DFU Request Complete")
     elif sock.is_status_req:
         output_line("Status Request Complete")
     else:
@@ -1160,6 +1179,10 @@ if __name__ == '__main__':
     parser.add_argument(
         "-r", "--request-bootloader", action="store_true",
         help="Requests the bootloader and exits"
+    )
+    parser.add_argument(
+        "--request-dfu", action="store_true",
+        help="Requests the device reboot into ROM DFU mode and exits"
     )
     parser.add_argument(
         "-s", "--status", action="store_true",

--- a/src/command.c
+++ b/src/command.c
@@ -81,6 +81,9 @@ command_dispatch(uint8_t *buf, uint_fast8_t msglen)
         case CMD_COMPLETE:
             command_complete(data);
             break;
+        case CMD_DFU:
+            command_dfu(data);
+            break;
         case CMD_GET_CANBUS_ID:
             if (CONFIG_CANSERIAL) {
                 command_get_canbus_id(data);

--- a/src/command.h
+++ b/src/command.h
@@ -30,6 +30,7 @@
 #define CMD_REQ_BLOCK     0x14
 #define CMD_COMPLETE      0x15
 #define CMD_GET_CANBUS_ID 0x16
+#define CMD_DFU           0x17
 #define RESPONSE_ACK           0xa0
 #define RESPONSE_NACK          0xf1
 #define RESPONSE_COMMAND_ERROR 0xf2
@@ -58,6 +59,7 @@ void command_write_block(uint32_t *data);
 void command_eof(uint32_t *data);
 void command_complete(uint32_t *data);
 void command_get_canbus_id(uint32_t *data);
+void command_dfu(uint32_t *data);
 
 // command.c
 void command_respond_ack(uint32_t acked_cmd, uint32_t *out, uint32_t out_len);

--- a/src/flashcmd.c
+++ b/src/flashcmd.c
@@ -60,6 +60,39 @@ DECL_TASK(complete_task);
 
 
 /****************************************************************
+ * Command "dfu" handling
+ ****************************************************************/
+
+void dfu_reboot(void); // provided by stm32 board code
+
+static uint8_t dfu_requested;
+static uint32_t dfu_endtime;
+
+void
+command_dfu(uint32_t *data)
+{
+    if (!CONFIG_MACH_STM32) {
+        // ROM DFU entry only implemented on stm32
+        command_respond_command_error();
+        return;
+    }
+    uint32_t out[3];
+    command_respond_ack(CMD_DFU, out, ARRAY_SIZE(out));
+    dfu_requested = 1;
+    dfu_endtime = timer_read_time() + timer_from_us(100000);
+}
+
+void
+dfu_task(void)
+{
+    if (CONFIG_MACH_STM32 && dfu_requested
+        && timer_is_before(dfu_endtime, timer_read_time()))
+        dfu_reboot();
+}
+DECL_TASK(dfu_task);
+
+
+/****************************************************************
  * Flash commands
  ****************************************************************/
 

--- a/src/stm32/dfu_reboot.c
+++ b/src/stm32/dfu_reboot.c
@@ -5,15 +5,53 @@
 // This file may be distributed under the terms of the GNU GPLv3 license.
 
 #include "internal.h" // NVIC_SystemReset
+#include "board/irq.h" // irq_disable
+
+// Many stm32 chips have a USB capable "DFU bootloader" in their ROM.
+// In order to invoke that bootloader it is necessary to reset the
+// chip and jump to a chip specific hardware address.
+//
+// To reset the chip, the dfu_reboot() code sets a flag in memory (at
+// an arbitrary position that is unlikely to be overwritten during a
+// chip reset), and resets the chip.  If dfu_reboot_check() sees that
+// flag on the next boot it will perform a code jump to the ROM
+// address.
+
+// Location of ram address to set internal flag
+#if CONFIG_MACH_STM32H7
+  #define USB_BOOT_FLAG_ADDR (0x24000000 + 0x8000) // Place flag in "AXI SRAM"
+#else
+  #define USB_BOOT_FLAG_ADDR (CONFIG_RAM_START + CONFIG_RAM_SIZE - 1024)
+#endif
+
+// Signature to set in memory to flag that a dfu reboot is requested
+#define USB_BOOT_FLAG 0x55534220424f4f54 // "USB BOOT"
 
 // Flag that bootloader is desired and reboot
 void
 dfu_reboot(void)
 {
+    if (!CONFIG_STM32_DFU_ROM_ADDRESS)
+        return;
+    irq_disable();
+    uint64_t *bflag = (void*)USB_BOOT_FLAG_ADDR;
+    *bflag = USB_BOOT_FLAG;
+#if __CORTEX_M >= 7
+    SCB_CleanDCache_by_Addr((void*)bflag, sizeof(*bflag));
+#endif
+    NVIC_SystemReset();
 }
 
 // Check if rebooting into system DFU Bootloader
 void
 dfu_reboot_check(void)
 {
+    if (!CONFIG_STM32_DFU_ROM_ADDRESS)
+        return;
+    if (*(uint64_t*)USB_BOOT_FLAG_ADDR != USB_BOOT_FLAG)
+        return;
+    *(uint64_t*)USB_BOOT_FLAG_ADDR = 0;
+    uint32_t *sysbase = (uint32_t*)CONFIG_STM32_DFU_ROM_ADDRESS;
+    asm volatile("mov sp, %0\n bx %1"
+                 : : "r"(sysbase[0]), "r"(sysbase[1]));
 }


### PR DESCRIPTION
## What

Completes the previously-stubbed ROM DFU reboot support for STM32 and makes it reachable from software:

- `src/stm32/dfu_reboot.c`: implement `dfu_reboot()` / `dfu_reboot_check()` (previously empty stubs). The implementation is taken verbatim from Klipper's `src/stm32/dfu_reboot.c` (Copyright Kevin O'Connor, GPLv3), whose copyright header this file already carries. It sets a `"USB BOOT"` flag near the top of RAM, resets, and on the next boot — before any clock/peripheral setup — loads SP/PC from `CONFIG_STM32_DFU_ROM_ADDRESS` and jumps into the ROM bootloader. The existing per-chip plumbing (`bootloader_request()` calling `dfu_reboot()`, `armcm_main()` calling `dfu_reboot_check()`) is unchanged.
- New protocol command `CMD_DFU` (0x17): asks a running Katapult to reboot into ROM DFU. Modeled directly on `CMD_COMPLETE`: respond with an ack, then act ~100ms later via a scheduled task so the response flushes first. On non-STM32 (or `STM32_DFU_ROM_ADDRESS=0`) the command is NACKed / a no-op.
- `flashtool.py --request-dfu`: sends the new command. Works over both transports — serial (`-d`) and CAN (`-i`/`-u`, including USB-to-CAN bridge boards, where flashtool's existing bridge handoff is reused).

## Why

Boards with broken or inaccessible BOOT0/RESET buttons currently have **no software path into ROM DFU once Katapult is installed**: Klipper's `bootloader_request()` intentionally prefers the Katapult signature over `dfu_reboot()`, and Katapult itself had only the empty stubs. Updating Katapult on such boards required physical button access (the deployer covers routine updates, but ROM DFU remains the recovery/reflash path).

## Why a new command rather than the 1200bps magic baud

Implementing the Arduino-style 1200bps trick inside Katapult's CDC handler was considered — it would need no flashtool change. It was rejected because:

- it is CDC-only: CAN-interface Katapult builds could never be asked over CAN, while `CMD_DFU` works uniformly over both transports the dispatcher already serves;
- 1200bps elsewhere in this ecosystem means "enter the bootloader" — overloading it to mean "leave the bootloader for ROM DFU" is a semantic trap;
- an explicit command matches Katapult's protocol architecture and degrades cleanly in both directions: an old flashtool is unaffected, and the new flag against an old Katapult gets a clean NACK.

Happy to rework the trigger shape if you prefer the magic-baud route — the `dfu_reboot.c` completion is identical either way.

## Testing

Verified on a Fysetc Spider v3.0 (STM32F446, Klipper in USB-to-CAN bridge mode):

```
Klipper (1d50:606f) --flashtool -i can0 -u <uuid> -r--> Katapult (1d50:6177)
Katapult --flashtool -d <serial> --request-dfu--> ROM DFU (0483:df11)
dfu-util -a 0 --dfuse-address 0x08000000:force:leave -D katapult.bin --> back to Klipper
```

Full cycle runs with no physical button presses.
