### PR TITLE
flashtool: match CAN bridge by USB id only, not manufacturer string

### DIFF
--- a/scripts/flashtool.py
+++ b/scripts/flashtool.py
@@ -753,10 +753,13 @@ class CanSocket(BaseSocket):
             if not item.joinpath("bDeviceClass").is_file():
                 continue
             usb_info = get_usb_info(item)
-            if (
-                usb_info["usb_id"] != GS_CAN_USB_ID or
-                usb_info["manufacturer"] != "klipper"
-            ):
+            # Match on the gs_usb VID:PID only.  The manufacturer string is
+            # configurable in Klipper (CONFIG_USB_MANUFACTURER) and differs
+            # on forks (e.g. "Kalico"), so it cannot be relied upon.  The
+            # can interface ownership check below and the serial number to
+            # UUID comparison that follows are sufficient to identify the
+            # bridge.
+            if usb_info["usb_id"] != GS_CAN_USB_ID:
                 continue
             if not list(item.glob(f"{item.name}:*/net/{can_intf}")):
                 continue


### PR DESCRIPTION
## Problem

`_search_canbus_bridge()` requires the USB manufacturer string to equal `"klipper"` in addition to the gs_usb VID:PID (`1d50:606f`). The manufacturer string is configurable in Klipper (`CONFIG_USB_MANUFACTURER`, used by the bridge's string descriptors) and differs on forks — e.g. Kalico ships `"Kalico"`. On such bridges flashtool fails to detect the bridge: it sends the reboot request "blind", the bridge drops to Katapult-USB taking the CAN interface with it, and the flash times out on a dead bus.

## Change

Match the bridge on the gs_usb VID:PID only. The remaining checks are sufficient to identify it: the sysfs walk already verifies the device *owns the CAN network interface*, and the serial-number→UUID comparison that follows verifies it is the requested node.

## Testing

Verified on a Fysetc Spider v3.0 (STM32F446, Klipper USB-to-CAN bridge built with `CONFIG_USB_MANUFACTURER="Kalico"`): before the change, bridge detection failed; after, `flashtool.py -i can0 -u <uuid> -f klipper.bin` completes the full bridge handoff and SHA-verified flash.

Found while testing #185 on a Kalico-branded bridge.
